### PR TITLE
uHAL : Implement read block method for IPbus configuration address space

### DIFF
--- a/cactuscore/uhal/pycohal/src/common/cactus_pycohal.cpp
+++ b/cactuscore/uhal/pycohal/src/common/cactus_pycohal.cpp
@@ -13,6 +13,7 @@
 // uhal includes
 #include "uhal/ClientInterface.hpp"
 #include "uhal/ConnectionManager.hpp"
+#include "uhal/ProtocolIPbusCore.hpp"
 #include "uhal/ProtocolTCP.hpp"
 #include "uhal/ProtocolUDP.hpp"
 #include "uhal/Node.hpp"
@@ -161,6 +162,10 @@ namespace pycohal
     }
   };
 
+  uhal::ValWord< uint32_t > readIPbusConfigurationSpace (uhal::IPbusCore& aClient, const uint32_t& aAddr )
+  {
+    return aClient.readConfigurationSpace(aAddr);
+  }
 }//namespace pycohal
 
 
@@ -227,6 +232,8 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS ( uhal_ClientInterface_write_overloads,  
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS ( uhal_ClientInterface_writeBlock_overloads, writeBlock, 2, 3 )
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS ( uhal_ClientInterface_read_overloads,       read,       1, 2 )
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS ( uhal_ClientInterface_readBlock_overloads,  readBlock,  2, 3 )
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS ( uhal_IPbusCore_read_overloads,             read,       1, 2 )
+
 
 // *** N.B: The argument of this BOOST_PYTHON_MODULE macro MUST be the same as the name of the library created, i.e. if creating library file my_py_binds_module.so , imported in python as:
 //                import my_py_binds_module
@@ -320,6 +327,13 @@ BOOST_PYTHON_MODULE ( _core )
          .def ( "getTimeoutPeriod", &uhal::ClientInterface::getTimeoutPeriod )
          .def ( /*__str__*/ self_ns::str ( self ) )
          ;
+
+  class_<uhal::IPbusCore, bases<uhal::ClientInterface>, boost::noncopyable /* no to-python converter (would require a copy CTOR) */,
+         boost::shared_ptr<uhal::IPbusCore> /* all instances are held within boost::shared_ptr */ >("IPbusCore", no_init /* no CTORs */)
+         .def ( "readConfigurationSpace", ( uhal::ValWord<uint32_t> ( uhal::IPbusCore::* ) ( const uint32_t&, const uint32_t& ) ) 0, uhal_IPbusCore_read_overloads() )
+         ;
+  def ("readIPbusConfigurationSpace", pycohal::readIPbusConfigurationSpace);
+
   // Wrap uhal::HwInterface
   class_<uhal::HwInterface> ( "HwInterface", init<const uhal::HwInterface&>() )
   .def ( "getClient", &uhal::HwInterface::getClient, pycohal::norm_ref_return_policy() )

--- a/cactuscore/uhal/uhal/include/uhal/ClientInterface.hpp
+++ b/cactuscore/uhal/uhal/include/uhal/ClientInterface.hpp
@@ -57,6 +57,7 @@ namespace uhal
 {
   // Forward declaration
   class Buffers;
+  class IPbusCore;
 
   namespace exception
   {
@@ -408,6 +409,7 @@ namespace uhal
       //! Timeout period for transactions
       boost::posix_time::time_duration mTimeoutPeriod;
 
+      friend class IPbusCore;
 
     protected:
 

--- a/cactuscore/uhal/uhal/include/uhal/ProtocolIPbusCore.hpp
+++ b/cactuscore/uhal/uhal/include/uhal/ProtocolIPbusCore.hpp
@@ -61,7 +61,8 @@ namespace uhal
     RMW_SUM,
     R_A_I,
     NI_READ,
-    NI_WRITE
+    NI_WRITE,
+    CONFIG_SPACE_READ
   };
 }
 
@@ -123,6 +124,22 @@ namespace uhal
       //       */
       //       virtual uint64_t getTimeoutPeriod();
 
+
+      /**
+        Read a single, unmasked, unsigned word from the configuration address space
+        @param aAddr the address of the register to read
+        @return a Validated Memory which wraps the location to which the reply data is to be written
+      */
+      ValWord< uint32_t > readConfigurationSpace ( const uint32_t& aAddr );
+
+      /**
+        Read a single, masked, unsigned word from the configuration address space
+        @param aAddr the address of the register to read
+        @param aMask the mask to apply to the value after reading
+        @return a Validated Memory which wraps the location to which the reply data is to be written
+      */
+      ValWord< uint32_t > readConfigurationSpace ( const uint32_t& aAddr, const uint32_t& aMask );
+
     protected:
 
       /**
@@ -173,6 +190,13 @@ namespace uhal
       */
       virtual ValVector< uint32_t > implementReadBlock ( const uint32_t& aAddr, const uint32_t& aSize, const defs::BlockReadWriteMode& aMode=defs::INCREMENTAL );
 
+      /**
+      Read a single, masked, unsigned word from the configuration address space
+      @param aAddr the address of the register to read
+      @param aMask the mask to apply to the value after reading
+      @return a Validated Memory which wraps the location to which the reply data is to be written
+      */
+      virtual ValWord< uint32_t > implementReadConfigurationSpace ( const uint32_t& aAddr, const uint32_t& aMask = defs::NOMASK );
 
       /**
       Read the value of a register, apply the AND-term, apply the OR-term, set the register to this new value and return a copy of the new value to the user

--- a/cactuscore/uhal/uhal/include/uhal/TemplateDefinitions/ProtocolIPbus.hxx
+++ b/cactuscore/uhal/uhal/include/uhal/TemplateDefinitions/ProtocolIPbus.hxx
@@ -122,6 +122,12 @@ namespace uhal
       case NI_WRITE :
         lType = 0x48;
         break;
+      case CONFIG_SPACE_READ :
+      {
+        exception::ValidationError lExc;
+        log ( lExc , "Configuration space read undefined in IPbus version 1" );
+        throw lExc;
+      }
     }
 
     return ( 0x10000000 | ( ( aTransactionId&0x7ff ) <<17 ) | ( ( aWordCount&0x1ff ) <<8 ) | lType | ( aInfoCode&0x7 ) );
@@ -364,6 +370,9 @@ namespace uhal
       case RMW_SUM :
         lType = 0x50;
         break;
+      case CONFIG_SPACE_READ :
+        lType = 0x60;
+        break;
       case R_A_I :
       {
         exception::ValidationError lExc;
@@ -413,6 +422,9 @@ namespace uhal
         break;
       case 0x50 :
         aType = RMW_SUM;
+        break;
+      case 0x60 :
+        aType = CONFIG_SPACE_READ;
         break;
       default:
         log ( Error() , "Unknown IPbus-header " , Integer ( uint8_t ( ( aHeader & 0xF0 ) >>4 ) , IntFmt<hex,fixed>() ) );


### PR DESCRIPTION
Addresses issue #19

Two notable aspects of this implementation:

 1. **Python bindings** Despite having added the `uhal::IPbusCore` class to the Python bindings, Python complains when I try to call the new `readConfigurationSpace` member function on instance of classes that inherit from `uhal::IPbusCore` - e.g:
```
>>> mp0.getClient().readConfigurationSpace()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'ClientInterface' object has no attribute 'readConfigurationSpace'
```
  Where `mp0` is a `HwInterface` instance with URI beginning `chtcp-2.0`. I have not been able to find a solution to this problem. However I have discovered that instances of classes that inherit from `uhal::IPbusCore` are accepted as the argument of Python bindings of functions if the corresponding argument to the C++ function is a `uhal::IPbusCore` reference. So, the Python bindings contain the function `uhal.readIPbusConfigurationSpace`, which is implemented in C++ (in the Python bindings library itself) as:
```
  uhal::ValWord< uint32_t > readIPbusConfigurationSpace (uhal::IPbusCore& aClient, const uint32_t& aAddr )
  {
    return aClient.readConfigurationSpace(aAddr);
  }
```

 2. **Thread safety** All of the `ClientInterface` class' public read/write methods lock the boost mutex `mUserSideMutex`, in order to allow them to be safely called from multiple threads simultaneously. However, this variable is not currently accessible from the `IPbusCore` class, in which the new `readConfigurationSpace` member functions are implemented.
    *  To work around this, for the moment, I have added `IPbusCore` as a friend class of `ClientInterface`
    * This is a **temporary** fix to expediate a new release containing this feature, but ideally should be replaced with a permanant solution ASAP.
    * The only alternative I can currently think of is to change `mUserSideMutex` from `private` to `protected`, however this solution would give a much larger codebase access to `mUserSideMutex`, whilst it would only be used in the `ClientInterface` and `IPbusCore` classes. I do not want to widen the accessibility of this variable that far without trying to find other alternatives first, so I have gone with the less pretty friend-based solution for the moment.

I have no other qualms with this implementation; it has been tested by reading the configuration space within an MP7 running "null algo" firmware (v2.2.1 of MP7 core).