### PR TITLE
ControlHub : Add logging-related dependencies to RPM specfile

### DIFF
--- a/cactuscore/controlhub/pkg/cactuscore-controlhub.spec.rhel7.post-preun-scriptlets
+++ b/cactuscore/controlhub/pkg/cactuscore-controlhub.spec.rhel7.post-preun-scriptlets
@@ -5,7 +5,7 @@ chmod 644 /var/log/controlhub/controlhub.log
 # 1) Must stop ControlHub in case RPM being upgraded (i.e. rpm -U), or in case of error on previous RPM erase
 systemctl stop controlhub
 # 1b) Restart rsyslog so that it picks up configuration file change
-/sbin/service rsyslog restart
+systemctl restart rsyslog
 # 2) Normal ControlHub start steps
 systemctl daemon-reload
 systemctl enable controlhub

--- a/cactuscore/controlhub/pkg/cactuscore-controlhub.spec.template
+++ b/cactuscore/controlhub/pkg/cactuscore-controlhub.spec.template
@@ -11,7 +11,7 @@ URL: http://www.erlang.org/
 Group: CACTUS
 Source: %{tarball_file}
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
-Requires: psmisc
+Requires: psmisc rsyslog logrotate
 
 
 %description


### PR DESCRIPTION
Addresses issue #28 by changing ControlHub RPM's `Requires` field to `psmisc rsyslog logrotate`