### PR TITLE
Use system version of pugixml on CentOS7

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -100,7 +100,7 @@ build:centos7:
     - tags
     - triggers
   before_script:
-    - sudo yum -y install boost-devel
+    - sudo yum -y install boost-devel pugixml-devel
     - sudo yum -y install createrepo krb5-workstation openssh-clients
     - mkdir -p ~/.ssh
     - echo "HOST lxplus" > ~/.ssh/config

--- a/config/Makefile.macros
+++ b/config/Makefile.macros
@@ -29,8 +29,8 @@ $(info OS Detected: $(CACTUS_OS))
 ifneq ($(CACTUS_OS), centos7)
     BUILD_ERLANG?=1
     BUILD_BOOST?=1
+    BUILD_PUGIXML?=1
 endif
-BUILD_PUGIXML?=1
 
 
 #extern/erlang
@@ -51,6 +51,9 @@ ifeq ($(BUILD_PUGIXML), 1)
     EXTERN_PUGIXML_PREFIX = $(CACTUS_RPM_ROOT)/extern/pugixml/RPMBUILD/SOURCES
     EXTERN_PUGIXML_INCLUDE_PREFIX = ${EXTERN_PUGIXML_PREFIX}/include
     EXTERN_PUGIXML_LIB_PREFIX = ${EXTERN_PUGIXML_PREFIX}/lib
+    PUGIXML_LIB_NAME = cactus_extern_pugixml
+else
+    PUGIXML_LIB_NAME = pugixml
 endif
 
 

--- a/extern/pugixml/Makefile
+++ b/extern/pugixml/Makefile
@@ -11,7 +11,7 @@ Packager = Andrew Rose, Marc Magrans de Abril
 
 PACKAGE_VER_MAJOR = 1
 PACKAGE_VER_MINOR = 2
-PACKAGE_RELEASE = 0
+PACKAGE_RELEASE = 1
 
 LIBRARY = libcactus_extern_pugixml.so
 
@@ -39,9 +39,9 @@ _all:
 	g++ -fPIC -O3 -shared -o ${LIBRARY} src/pugixml.cpp;								\
 	date > .build_done;											\
 	mkdir -p ${RPMBUILD_DIR}/{RPMS/{i386,i586,i686,x86_64},SPECS,BUILD,SOURCES,SRPMS};	\
-	mkdir -p ${RPMBUILD_DIR}/SOURCES/{lib,include/pugixml};								\
+	mkdir -p ${RPMBUILD_DIR}/SOURCES/{lib,include};								\
 	cp ${LIBRARY} ${RPMBUILD_DIR}/SOURCES/lib;								\
-	cp src/*.hpp ${RPMBUILD_DIR}/SOURCES/include/pugixml;	\
+	cp src/*.hpp ${RPMBUILD_DIR}/SOURCES/include;	\
 	fi;	
 rpm: _rpmall
 _rpmall: 

--- a/uhal/pycohal/Makefile
+++ b/uhal/pycohal/Makefile
@@ -41,7 +41,7 @@ BINDING_LIBRARIES = 	\
 			-lboost_system \
 			-lboost_thread \
 			\
-			-lcactus_extern_pugixml \
+			-l${PUGIXML_LIB_NAME} \
 			-lcactus_uhal_grammars \
 			-lcactus_uhal_log \
 			-lcactus_uhal_uhal

--- a/uhal/tests/Makefile
+++ b/uhal/tests/Makefile
@@ -41,7 +41,7 @@ LIBRARIES = 	\
 		-lboost_thread \
 		-lboost_program_options \
 		\
-		-lcactus_extern_pugixml \
+		-l${PUGIXML_LIB_NAME} \
 		-lcactus_uhal_log \
 		-lcactus_uhal_grammars \
 		-lcactus_uhal_uhal	

--- a/uhal/uhal/Makefile
+++ b/uhal/uhal/Makefile
@@ -27,7 +27,7 @@ LIBRARY_PATH := $(addprefix -L,$(LIBRARY_PATH))
 
 LIBRARIES = 	-lpthread \
 		\
-		-lcactus_extern_pugixml \
+		-l${PUGIXML_LIB_NAME} \
 		\
 		-lboost_thread \
 		-lboost_system \

--- a/uhal/uhal/include/uhal/NodeTreeBuilder.hpp
+++ b/uhal/uhal/include/uhal/NodeTreeBuilder.hpp
@@ -51,7 +51,7 @@
 #include "uhal/grammars/NodeTreeParametersGrammar.hpp"
 #include "uhal/grammars/NodeTreeFirmwareInfoAttributeGrammar.hpp"
 
-#include "pugixml/pugixml.hpp"
+#include "pugixml.hpp"
 
 #include "uhal/XmlParser.hpp"
 

--- a/uhal/uhal/include/uhal/Utilities.hpp
+++ b/uhal/uhal/include/uhal/Utilities.hpp
@@ -67,7 +67,7 @@
 #include "uhal/grammars/HttpResponseGrammar.hpp"
 #include "uhal/grammars/URLGrammar.hpp"
 
-#include "pugixml/pugixml.hpp"
+#include "pugixml.hpp"
 
 #include "uhal/log/log.hpp"
 #include "uhal/log/exception.hpp"

--- a/uhal/uhal/include/uhal/XmlParser.hpp
+++ b/uhal/uhal/include/uhal/XmlParser.hpp
@@ -43,7 +43,7 @@
 #include <deque>
 #include <set>
 
-#include "pugixml/pugixml.hpp"
+#include "pugixml.hpp"
 #include "uhal/log/log.hpp"
 #include "uhal/Utilities.hpp"
 #include "uhal/log/exception.hpp"

--- a/yumgroups-centos7.xml
+++ b/yumgroups-centos7.xml
@@ -8,7 +8,6 @@
     <uservisible>true</uservisible>
     <grouplist></grouplist>
     <packagelist>
-      <packagereq type="mandatory">cactuscore-extern-pugixml</packagereq>
       <packagereq type="mandatory">cactuscore-uhal-grammars</packagereq>
       <packagereq type="mandatory">cactuscore-uhal-log</packagereq>
       <packagereq type="mandatory">cactuscore-uhal-uhal</packagereq>


### PR DESCRIPTION
Addresses issue #49 

Notably:
 * The standard `pugixml` RPM (i.e. that from the EPEL) installs the pugixml headers directly under `/usr/include` (not in a `pugixml` subdirectory), and so I had to update the `cactuscore-extern-pugixml` RPM to install the `pugixml` headers directly under `/opt/cactus/include`
 * A new environment variable, `PUGIXML_LIB_NAME`, was added to `config/Makefile.macros` in order to cope with the different filenames of the pugixml library in `cactuscore-extern-pugixml` and in the EPEL `pugixml` RPM 