### PR TITLE
CI : Migrate CC7 jobs from docker-ssh executor (being deprecated) to plain docker

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -154,7 +154,7 @@ build:centos7:
 
 .job_template: &centos7_test_job
   stage: test
-  image: tswilliams/ipbus-sw-test-cc7:latest
+  image: tswilliams/ipbus-sw-dev-cc7:latest
   except:
     - triggers
   dependencies: []
@@ -167,6 +167,7 @@ build:centos7:
     - sudo yum -y groupinstall uhal
     - sudo yum -y install which
     - rpm -qa | grep cactus | sort
+    - export TEST_SUITE_CONTROLHUB_PATH_ARGUMENT="-p /opt/cactus/bin"
 
 
 .job_template:
@@ -176,12 +177,12 @@ build:centos7:
     - env | grep -v PASSWORD | grep -v TOKEN
     - uhal_test_suite.py -v -s "1.3 udp"
     - uhal_test_suite.py -v -s "1.3 tcp"
-    - service controlhub stop || sudo systemctl stop controlhub
-    - uhal_test_suite.py -v -s "1.3 controlhub"
+    - service controlhub stop || /opt/cactus/bin/controlhub_stop || true
+    - uhal_test_suite.py -v -s "1.3 controlhub" ${TEST_SUITE_CONTROLHUB_PATH_ARGUMENT}
     - uhal_test_suite.py -v -s "2.0 udp"
     - uhal_test_suite.py -v -s "2.0 tcp"
-    - uhal_test_suite.py -v -s "2.0 controlhub - normal"
-    - uhal_test_suite.py -v -s "2.0 controlhub - light packet loss"
+    - uhal_test_suite.py -v -s "2.0 controlhub - normal" ${TEST_SUITE_CONTROLHUB_PATH_ARGUMENT}
+    - uhal_test_suite.py -v -s "2.0 controlhub - light packet loss" ${TEST_SUITE_CONTROLHUB_PATH_ARGUMENT}
 
 .job_template:
   script: &test_python_script
@@ -246,36 +247,33 @@ test_controlhub:slc6:
 test_core:centos7:
   <<: *centos7_test_job
   tags:
-    - docker-ssh
-    - docker-cap-sys-admin
+    - docker
     - docker-cap-net-admin
   script: *test_core_script
 
 test_python:centos7:
   <<: *centos7_test_job
   tags:
-    - docker-ssh
-    - docker-cap-sys-admin
+    - docker
   script: *test_python_script
 
 test_gui:centos7:
   <<: *centos7_test_job
   tags:
-    - docker-ssh
+    - docker
   script: *test_gui_script
 
 test_tools:centos7:
   <<: *centos7_test_job
   tags:
-    - docker-ssh
+    - docker
   script: *test_tools_script
 
 test_controlhub:centos7:
   <<: *centos7_test_job
   tags:
-    - docker-ssh
-    - docker-cap-sys-admin
+    - docker
   script: 
-    - sudo systemctl stop controlhub
+    - /opt/cactus/bin/controlhub_stop || true
     - env | grep -v PASSWORD | grep -v TOKEN
-    - 'for i in `seq 1 50`; do sudo systemctl start controlhub; if [ "$?" != "0" ]; then echo "ERROR IN STARTING CONTROLHUB"; fi; systemctl status controlhub; if [ "$?" != "0" ]; then echo "ERROR: CONTROLHUB SHOULD HAVE ALREADY STARTED"; fi; sudo systemctl stop controlhub; done'
+    - 'for i in `seq 1 50`; do /opt/cactus/bin/controlhub_start; if [ "$?" != "0" ]; then echo "ERROR IN STARTING CONTROLHUB"; fi; /opt/cactus/bin/controlhub_status; if [ "$?" != "0" ]; then echo "ERROR: CONTROLHUB SHOULD HAVE ALREADY STARTED"; fi; /opt/cactus/bin/controlhub_stop; done'

--- a/uhal/tests/scripts/uhal_test_suite.py
+++ b/uhal/tests/scripts/uhal_test_suite.py
@@ -11,6 +11,7 @@ All options/arguments are optional:
    -c /path/to/dummy_conns.xml : Full path to dummy_connections.xml (without file:// prefix)
    -s search_string            : If specified, only sections that contain this string will be run (case-insenstive search).
                                  Otherwise, all sections will be run (see section list at end).
+   -p                          : Path containing ControlHub scripts that will be used
    -x                          : Quit on first error
 
 E.g:
@@ -619,7 +620,7 @@ def run_command(cmd, verbose=True):
 if __name__=="__main__":
     # Parse options
     try:
-        opts, args = getopt.getopt(sys.argv[1:], "xhvls:c:", ["help"])
+        opts, args = getopt.getopt(sys.argv[1:], "xhvlp:s:c:", ["help"])
     except getopt.GetoptError, err:
         print __doc__
         sys.exit(2)
@@ -629,6 +630,7 @@ if __name__=="__main__":
     conn_file = "/opt/cactus/etc/uhal/tests/dummy_connections.xml"
     section_search_str = None
     quit_on_error = False
+    controlhub_scripts_dir = None
 
     stdout = []
     exit_code = 0
@@ -652,6 +654,8 @@ if __name__=="__main__":
             section_search_str = value
         elif opt == "-x":
             quit_on_error = True
+        elif opt == "-p":
+            controlhub_scripts_dir = value
 
     if len(args) != 0:
         print "Incorrect usage!"
@@ -662,13 +666,14 @@ if __name__=="__main__":
     print "  connections file:       ",  conn_file
 
     # Find directory for controlhub commands
-    which_controlhub_status = run_command("which controlhub_status", False)
-    if which_controlhub_status[1]:
-        controlhub_scripts_dir = "/opt/cactus/bin"
-    else:
-        controlhub_scripts_dir = os.path.dirname( which_controlhub_status[0][0].rstrip("\n") )
-    if controlhub_scripts_dir.startswith("/opt/cactus/bin"):
-        controlhub_scripts_dir = None
+    if controlhub_scripts_dir is None:
+        which_controlhub_status = run_command("which controlhub_status", False)
+        if which_controlhub_status[1]:
+            controlhub_scripts_dir = "/opt/cactus/bin"
+        else:
+            controlhub_scripts_dir = os.path.dirname( which_controlhub_status[0][0].rstrip("\n") )
+        if controlhub_scripts_dir.startswith("/opt/cactus/bin"):
+            controlhub_scripts_dir = None
     print '  ControlHub scripts dir: ', controlhub_scripts_dir
 
     # Get uhal tools template file name


### PR DESCRIPTION
The gitlab CI docker-ssh executor is being deprecated in upcoming gitlab releases.

This pull request (part of issue #51) changes the CC7 test jobs from using the docker-ssh executor, to using plain docker; this is achieved by directly running the ControlHub's scripts to start/stop it, rather than using `systemctl`.