### PR TITLE
Update CI config to use tagged docker images from gitlab registry

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,7 +17,7 @@ variables:
 
 github_commit_status:start:
   stage: initial_report
-  image: tswilliams/ipbus-sw-dev-cc7:latest
+  image: cern/cc7-base:20170113
   tags:
     - docker
   except:
@@ -29,7 +29,7 @@ github_commit_status:start:
 
 github_commit_status:end:failure:
   stage: final_report
-  image: tswilliams/ipbus-sw-dev-cc7:latest
+  image: cern/cc7-base:20170113
   tags:
     - docker
   except:
@@ -42,7 +42,7 @@ github_commit_status:end:failure:
 
 github_commit_status:end:success:
   stage: final_report
-  image: tswilliams/ipbus-sw-dev-cc7:latest
+  image: cern/cc7-base:20170113
   tags:
     - docker
   except:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -92,10 +92,8 @@ doxygen_job:
   except:
     - triggers
   before_script:
-    - sudo rpm --rebuilddb && sudo yum clean all 
-    - sudo yum -y install createrepo ${ADDITIONAL_RPMS_TO_INSTALL}
-  script:
     - export REPO_DIR=${CI_PROJECT_DIR}/ci_build_results/repos/${OUTPUT_REPO_SUBDIR}
+  script:
     - env | grep -v PASSWORD | grep -v TOKEN
     - cd .. && sudo rm -rf ipbus-software____ && mv ipbus-software ipbus-software____ && mkdir ipbus-software && cd ipbus-software____
     - make -k Set=all
@@ -113,18 +111,16 @@ doxygen_job:
 
 build:slc6:
   <<: *build_job
-  image: tswilliams/ipbus-sw-dev-slc6:latest
+  image: gitlab-registry.cern.ch/ipbus/ipbus-docker/ipbus-sw-dev-slc6:2017-10-31
   variables:
-    ADDITIONAL_RPMS_TO_INSTALL: ""
     YUMGROUPS_FILE: "ci/yumgroups-slc6.xml"
     OUTPUT_REPO_SUBDIR: "slc6_x86_64"
 
 
 build:centos7:
   <<: *build_job
-  image: tswilliams/ipbus-sw-dev-cc7:latest
+  image: gitlab-registry.cern.ch/ipbus/ipbus-docker/ipbus-sw-dev-cc7:2017-10-31__boost1.53.0_pugixml1.8
   variables:
-    ADDITIONAL_RPMS_TO_INSTALL: "boost-devel pugixml-devel"
     YUMGROUPS_FILE: "ci/yumgroups-centos7.xml"
     OUTPUT_REPO_SUBDIR: "centos7_x86_64"
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,7 @@
 stages:
   - initial_report
   - build
+  - publish_build
   - test
   - final_report
 
@@ -36,6 +37,7 @@ github_commit_status:end:failure:
   when: on_failure
   script:
     - "curl -H \"Authorization: token ${GITHUB_STATUS_TOKEN}\" --data '{\"state\" : \"failure\", \"target_url\" : \"'\"${CI_PROJECT_URL}\"'/pipelines/'\"${CI_PIPELINE_ID}\"'\", \"description\" : \"Jobs have failed in CI pipeline\", \"context\" : \"gitlab-ci\"}' ${GITHUB_REPO_API_URL}/statuses/${CI_BUILD_REF}"
+  dependencies: []
 
 github_commit_status:end:success:
   stage: final_report
@@ -48,7 +50,7 @@ github_commit_status:end:success:
   when: on_success
   script:
     - "curl -H \"Authorization: token ${GITHUB_STATUS_TOKEN}\" --data '{\"state\" : \"success\", \"target_url\" : \"'\"${CI_PROJECT_URL}\"'/pipelines/'\"${CI_PIPELINE_ID}\"'\", \"description\" : \"CI pipeline completed successfully!\", \"context\" : \"gitlab-ci\"}' ${GITHUB_REPO_API_URL}/statuses/${CI_BUILD_REF}"
-
+  dependencies: []
 
 
 doxygen_job:
@@ -60,32 +62,25 @@ doxygen_job:
     - triggers
   before_script:
     - sudo rpm --rebuilddb && sudo yum clean all 
-    - sudo yum -y install graphviz
-    - sudo yum -y install make krb5-workstation openssh-clients
+    - sudo yum -y install graphviz make
     - sudo yum -y remove doxygen
     - curl -O https://svnweb.cern.ch/trac/cactus/export/47232/trunk/scripts/nightly/doxygen/doxygen-1.8.6.src.tar.gz
     - tar xzf doxygen-1.8.6.src.tar.gz
     - cd doxygen-1.8.6
     - ./configure --prefix /usr --docdir /usr/share/doc/doxygen-1.8.6 && make
     - sudo make MAN1DIR=share/man/man1 install
-    - mkdir -p ~/.ssh  &&  cp ${CI_PROJECT_DIR}/ci/ssh_config ~/.ssh/config
-    - export OUTPUT_PIPELINE_DIR=${OUTPUT_ROOT_DIR}/commits/${CI_COMMIT_TAG:-${CI_COMMIT_SHA}}/pipeline${CI_PIPELINE_ID}
-    - if [ -n "${CI_COMMIT_TAG}" ]; then export OUTPUT_PIPELINE_DIR=${OUTPUT_PIPELINE_DIR/commits/tags} ; fi
   script:
     - env | grep -v PASSWORD | grep -v TOKEN
     - cd ${CI_PROJECT_DIR}
     - ./scripts/doxygen/api_uhal.sh "(${CI_COMMIT_TAG:-commit ${CI_COMMIT_SHA}})"
     - ls -al /tmp
-    - echo "${KRB_PASSWORD}" | kinit ${KRB_USERNAME}@CERN.CH
-    - klist
-    - ssh ${KRB_USERNAME}@lxplus "mkdir -p ${OUTPUT_PIPELINE_DIR}" 
-    - ssh ${KRB_USERNAME}@lxplus "ln -sfn ${OUTPUT_PIPELINE_DIR} `dirname ${OUTPUT_PIPELINE_DIR}`/latest" 
-    - rsync -av /tmp/api_uhal ${KRB_USERNAME}@lxplus:${OUTPUT_PIPELINE_DIR}/
+    - mkdir -p ${CI_PROJECT_DIR}/ci_build_results/
+    - mv /tmp/api_uhal ${CI_PROJECT_DIR}/ci_build_results/api_uhal
   artifacts:
-    untracked: true
+    paths:
+      - ci_build_results/api_uhal
     when: always
     expire_in: 1 day
-  allow_failure: true
 
 
 
@@ -98,25 +93,22 @@ doxygen_job:
     - triggers
   before_script:
     - sudo rpm --rebuilddb && sudo yum clean all 
-    - sudo yum -y install createrepo krb5-workstation openssh-clients ${ADDITIONAL_RPMS_TO_INSTALL}
-    - mkdir -p ~/.ssh  &&  cp ci/ssh_config ~/.ssh/config
-    - export OUTPUT_PIPELINE_DIR=${OUTPUT_ROOT_DIR}/commits/${CI_COMMIT_TAG:-${CI_COMMIT_SHA}}/pipeline${CI_PIPELINE_ID}
-    - if [ -n "${CI_COMMIT_TAG}" ]; then export OUTPUT_PIPELINE_DIR=${OUTPUT_PIPELINE_DIR/commits/tags} ; fi
+    - sudo yum -y install createrepo ${ADDITIONAL_RPMS_TO_INSTALL}
   script:
+    - export REPO_DIR=${CI_PROJECT_DIR}/ci_build_results/repos/${OUTPUT_REPO_SUBDIR}
     - env | grep -v PASSWORD | grep -v TOKEN
     - cd .. && sudo rm -rf ipbus-software____ && mv ipbus-software ipbus-software____ && mkdir ipbus-software && cd ipbus-software____
     - make -k Set=all
     - make -k Set=all rpm
-    - mkdir -p yumrepo
-    - cp `find . -iname "*.rpm"` yumrepo
-    - cp ${YUMGROUPS_FILE} yumrepo/yumgroups.xml
-    - ls yumrepo
-    - createrepo -vg yumgroups.xml yumrepo
-    - echo "${KRB_PASSWORD}" | kinit ${KRB_USERNAME}@CERN.CH
-    - klist
-    - ssh ${KRB_USERNAME}@lxplus "mkdir -p ${OUTPUT_PIPELINE_DIR}/repos"
-    - ssh ${KRB_USERNAME}@lxplus "ln -sfn ${OUTPUT_PIPELINE_DIR} `dirname ${OUTPUT_PIPELINE_DIR}`/latest" 
-    - rsync -av yumrepo/ ${KRB_USERNAME}@lxplus:${OUTPUT_PIPELINE_DIR}/repos/${OUTPUT_REPO_SUBDIR}
+    - mkdir -p ${REPO_DIR} 
+    - cp `find . -iname "*.rpm"` ${REPO_DIR} && cp ${YUMGROUPS_FILE} ${REPO_DIR}/yumgroups.xml
+    - ls ${REPO_DIR}
+    - createrepo -vg yumgroups.xml ${REPO_DIR}
+  artifacts:
+    paths:
+      - ci_build_results/repos/${OUTPUT_REPO_SUBDIR}
+    when: always
+    expire_in: 1 day
 
 
 build:slc6:
@@ -135,6 +127,28 @@ build:centos7:
     ADDITIONAL_RPMS_TO_INSTALL: "boost-devel pugixml-devel"
     YUMGROUPS_FILE: "ci/yumgroups-centos7.xml"
     OUTPUT_REPO_SUBDIR: "centos7_x86_64"
+
+
+
+
+publish_build_job:
+  stage: publish_build
+  image: gitlab-registry.cern.ch/ci-tools/ci-web-deployer:latest
+  variables:
+    CI_OUTPUT_DIR: "ci_build_results/"
+  before_script:
+    - yum -y install openssh-clients
+    - export EOS_PATH=${OUTPUT_ROOT_DIR}/commits/${CI_COMMIT_TAG:-${CI_COMMIT_SHA}}/pipeline${CI_PIPELINE_ID}
+    - if [ -n "${CI_COMMIT_TAG}" ]; then export EOS_PATH=${OUTPUT_PIPELINE_URL/commits/tags} ; fi
+  script:
+    - env | grep -v PASSWORD | grep -v TOKEN | sort
+    - echo "${EOS_ACCOUNT_PASSWORD}" | kinit ${EOS_ACCOUNT_USERNAME}@CERN.CH
+    - klist
+    - ssh -F ${CI_PROJECT_DIR}/ci/ssh_config ${EOS_ACCOUNT_USERNAME}@lxplus "rm -rf ${EOS_PATH} && mkdir -p ${EOS_PATH}"
+    - ssh -F ${CI_PROJECT_DIR}/ci/ssh_config ${EOS_ACCOUNT_USERNAME}@lxplus "ln -sfnv ${EOS_PATH} `dirname ${EOS_PATH}`/latest"
+    - kdestroy
+    - ls -lt ${CI_OUTPUT_DIR}
+    - deploy-eos
 
 
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,20 +55,11 @@ github_commit_status:end:success:
 
 doxygen_job:
   stage: build
-  image: tswilliams/ipbus-sw-dev-cc7:latest
+  image: gitlab-registry.cern.ch/ipbus/ipbus-docker/ipbus-sw-doxygen:master__doxygen1.8.13
   tags:
     - docker
   except:
     - triggers
-  before_script:
-    - sudo rpm --rebuilddb && sudo yum clean all 
-    - sudo yum -y install graphviz make
-    - sudo yum -y remove doxygen
-    - curl -O https://svnweb.cern.ch/trac/cactus/export/47232/trunk/scripts/nightly/doxygen/doxygen-1.8.6.src.tar.gz
-    - tar xzf doxygen-1.8.6.src.tar.gz
-    - cd doxygen-1.8.6
-    - ./configure --prefix /usr --docdir /usr/share/doc/doxygen-1.8.6 && make
-    - sudo make MAN1DIR=share/man/man1 install
   script:
     - env | grep -v PASSWORD | grep -v TOKEN
     - cd ${CI_PROJECT_DIR}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,6 +9,7 @@ stages:
 
 variables:
   GITHUB_REPO_API_URL: "https://api.github.com/repos/ipbus/ipbus-software"
+  IPBUS_DOCKER_REGISTRY: "gitlab-registry.cern.ch/ipbus/ipbus-docker"
   OUTPUT_ROOT_DIR: "/eos/user/i/ipbusci/sw-gitlab-ci"
   OUTPUT_ROOT_URL: "http://www.cern.ch/ipbus/sw/ci"
 
@@ -55,7 +56,7 @@ github_commit_status:end:success:
 
 doxygen_job:
   stage: build
-  image: gitlab-registry.cern.ch/ipbus/ipbus-docker/ipbus-sw-doxygen:master__doxygen1.8.13
+  image: ${IPBUS_DOCKER_REGISTRY}/ipbus-sw-doxygen:2017-11-04__doxygen1.8.13
   tags:
     - docker
   except:
@@ -102,7 +103,7 @@ doxygen_job:
 
 build:slc6:
   <<: *build_job
-  image: gitlab-registry.cern.ch/ipbus/ipbus-docker/ipbus-sw-dev-slc6:2017-10-31
+  image: ${IPBUS_DOCKER_REGISTRY}/ipbus-sw-dev-slc6:2017-11-04
   variables:
     YUMGROUPS_FILE: "ci/yumgroups-slc6.xml"
     OUTPUT_REPO_SUBDIR: "slc6_x86_64"
@@ -110,7 +111,7 @@ build:slc6:
 
 build:centos7:
   <<: *build_job
-  image: gitlab-registry.cern.ch/ipbus/ipbus-docker/ipbus-sw-dev-cc7:2017-10-31__boost1.53.0_pugixml1.8
+  image: ${IPBUS_DOCKER_REGISTRY}/ipbus-sw-dev-cc7:2017-11-04__boost1.53.0_pugixml1.8
   variables:
     YUMGROUPS_FILE: "ci/yumgroups-centos7.xml"
     OUTPUT_REPO_SUBDIR: "centos7_x86_64"
@@ -142,7 +143,7 @@ publish_build_job:
 
 .job_template: &slc6_test_job
   stage: test
-  image: tswilliams/ipbus-sw-dev-slc6:latest
+  image: ${IPBUS_DOCKER_REGISTRY}/ipbus-sw-test-slc6:2017-11-04
   except:
     - triggers
   dependencies: []
@@ -158,7 +159,7 @@ publish_build_job:
 
 .job_template: &centos7_test_job
   stage: test
-  image: tswilliams/ipbus-sw-dev-cc7:latest
+  image: ${IPBUS_DOCKER_REGISTRY}/ipbus-sw-test-cc7:2017-11-04
   except:
     - triggers
   dependencies: []
@@ -167,9 +168,8 @@ publish_build_job:
     - if [ -n "${CI_COMMIT_TAG}" ]; then export OUTPUT_PIPELINE_URL=${OUTPUT_PIPELINE_URL/commits/tags} ; fi
     - sudo cp ci/ipbus-sw-ci.repo /etc/yum.repos.d/ipbus-sw-ci.repo
     - sudo sed -i -re "s|^baseurl=.*|baseurl=${OUTPUT_PIPELINE_URL}/repos/centos7_x86_64|g" /etc/yum.repos.d/ipbus-sw-ci.repo
-    - sudo rpm --rebuilddb && sudo yum clean all 
+    - sudo rpm --rebuilddb && sudo yum clean all
     - sudo yum -y groupinstall uhal
-    - sudo yum -y install which
     - rpm -qa | grep cactus | sort
     - export TEST_SUITE_CONTROLHUB_PATH_ARGUMENT="-p /opt/cactus/bin"
 

--- a/ci/ssh_config
+++ b/ci/ssh_config
@@ -1,5 +1,6 @@
 HOST lxplus
   StrictHostKeyChecking no
+  UserKnownHostsFile /dev/null
   GSSAPITrustDns yes
   GSSAPIAuthentication yes
   GSSAPIDelegateCredentials yes

--- a/uhal/config/mfRPMRules.mk
+++ b/uhal/config/mfRPMRules.mk
@@ -5,8 +5,8 @@ BuildDebuginfoRPM ?= 1
 IncludePaths := $(if ${IncludePaths}, ${IncludePaths}, %{nil})
 PackageSummary := $(if ${PackageSummary}, ${PackageSummary}, None)
 PackageDescription := $(if ${PackageDescription}, ${PackageDescription}, None)
-BUILD_REQUIRES_TAG = $(if ${PackageBuildRequires}, BuildRequires: ${PackageBuildRequires} ,\# No BuildRequires tag )
-REQUIRES_TAG = $(if ${PackageRequires}, Requires: ${PackageRequires} ,\# No Requires tag )
+BUILD_REQUIRES_TAG = $(if ${PackageBuildRequires} ,BuildRequires: ${PackageBuildRequires} ,\# No BuildRequires tag )
+REQUIRES_TAG = $(if ${PackageRequires} ,Requires: ${PackageRequires} ,\# No Requires tag )
 
 export BUILD_HOME
 

--- a/uhal/tests/Makefile
+++ b/uhal/tests/Makefile
@@ -17,6 +17,7 @@ PackageSummary = uHAL Library Tests
 PackageDescription = uHAL Library Tests
 PackageURL = https://ipbus.web.cern.ch/ipbus
 Packager = Andrew Rose, Marc Magrans de Arbil, Tom Williams
+PackageRequires = which iproute
 
 
 Library = cactus_uhal_tests


### PR DESCRIPTION
CI config is updated to use tagged docker images from gitlab registry, or official CERN images from dockerhub; should also reduce time taken by some of the jobs (since `yum install` commands for build prerequisites now solely in dockerfiles). Addresses part of issue #51   