### PR TITLE
Update ControlHub to compile with Erlang 19

### DIFF
--- a/controlhub/ebin/controlhub.app
+++ b/controlhub/ebin/controlhub.app
@@ -25,7 +25,7 @@
                  ch_sup,
                  ch_tcp_listener]},
    {applications, [stdlib, kernel, sasl,
-                   appmon,
+                   observer,
                    % For lager syslog backend
                    syslog, lager_syslog,
                    % For lager, which depends on goldrush

--- a/controlhub/rebar.config
+++ b/controlhub/rebar.config
@@ -3,9 +3,9 @@
 % DEPENDENCIES
 
 {deps, [
-  {lager, "2\.0\.3", {git, "https://github.com/basho/lager.git", {tag, "2.0.3"}}},
-  {syslog, "1\.0\.2", {git, "https://github.com/Vagabond/erlang-syslog.git", {tag, "1.0.2"}}},
-  {lager_syslog, "2\.0\.3", {git, "https://github.com/basho/lager_syslog.git", {tag, "2.0.3"}}}
+  {lager, "3\.2\.2", {git, "https://github.com/basho/lager.git", {tag, "3.2.4"}}},
+  {syslog, "1\.0\.5", {git, "https://github.com/Vagabond/erlang-syslog.git", {tag, "1.0.5"}}},
+  {lager_syslog, "2\.1\.2", {git, "https://github.com/basho/lager_syslog.git", {tag, "3.0.3"}}}
 ]}.
 
 

--- a/controlhub/rebar.config
+++ b/controlhub/rebar.config
@@ -19,4 +19,8 @@
 %%%%%%%%%%%%%%%%%%
 % COMPILER FLAGS
 
-{erl_opts, [{parse_transform, lager_transform}]}.
+{erl_opts, [{parse_transform, lager_transform},
+            % Use new time API from Erlang version 18
+            % (Erlang releases from 17 onwards do not put R in front of name
+            {platform_define, "^(R|17).*", old_erlang_time_api}
+            ]}.

--- a/controlhub/src/ch_transaction_manager.erl
+++ b/controlhub/src/ch_transaction_manager.erl
@@ -29,7 +29,7 @@
                 target_ip_u32   :: non_neg_integer(),
                 target_port     :: non_neg_integer(),
                 nr_in_flight    :: non_neg_integer(),
-                q_nr_reqs_per_tcp :: queue(),
+                q_nr_reqs_per_tcp, % :: queue(),
                 reply_io_list   :: list(),
                 nr_replies_acc  :: non_neg_integer(),
                 stats_table


### PR DESCRIPTION
Part of issue #65 

Notable changes required to compile with v19 of Erlang:
 * Dependency on `appmon` app replaced by `observer` (`appmon` has been deprecated)
 * Versions of logging libraries (`lager`, `lager_syslog`, `syslog`) updated 
 * Use Erlang's new time API from Erlang v18