### PR TITLE
Run automated builds on more operating systems

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -117,6 +117,12 @@ build:centos7:
     OUTPUT_REPO_SUBDIR: "centos7_x86_64"
 
 
+build:fedora26:
+  <<: *build_job
+  image: ${IPBUS_DOCKER_REGISTRY}/ipbus-sw-dev-fedora26:2017-11-04__erlang19.3.6.3_gcc7.1.1_boost1.63.0_pugixml1.8
+  variables:
+    YUMGROUPS_FILE: "ci/yumgroups-centos7.xml"
+    OUTPUT_REPO_SUBDIR: "fedora26_x86_64"
 
 
 publish_build_job:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -77,7 +77,18 @@ doxygen_job:
 
 
 
-.job_template: &build_job
+.job_template: &simple_build_job
+  stage: build
+  tags:
+    - docker
+  except:
+    - triggers
+  script:
+    - env | grep -v PASSWORD | grep -v TOKEN
+    - make -k Set=all
+
+
+.job_template: &build_rpm_yumrepo_job
   stage: build
   tags:
     - docker
@@ -102,7 +113,7 @@ doxygen_job:
 
 
 build:slc6:
-  <<: *build_job
+  <<: *build_rpm_yumrepo_job
   image: ${IPBUS_DOCKER_REGISTRY}/ipbus-sw-dev-slc6:2017-11-04
   variables:
     YUMGROUPS_FILE: "ci/yumgroups-slc6.xml"
@@ -110,7 +121,7 @@ build:slc6:
 
 
 build:centos7:
-  <<: *build_job
+  <<: *build_rpm_yumrepo_job
   image: ${IPBUS_DOCKER_REGISTRY}/ipbus-sw-dev-cc7:2017-11-04__boost1.53.0_pugixml1.8
   variables:
     YUMGROUPS_FILE: "ci/yumgroups-centos7.xml"
@@ -118,11 +129,15 @@ build:centos7:
 
 
 build:fedora26:
-  <<: *build_job
+  <<: *simple_build_job
   image: ${IPBUS_DOCKER_REGISTRY}/ipbus-sw-dev-fedora26:2017-11-04__erlang19.3.6.3_gcc7.1.1_boost1.63.0_pugixml1.8
   variables:
     YUMGROUPS_FILE: "ci/yumgroups-centos7.xml"
     OUTPUT_REPO_SUBDIR: "fedora26_x86_64"
+
+build:ubuntu16:
+  <<: *simple_build_job
+  image: ${IPBUS_DOCKER_REGISTRY}/ipbus-sw-dev-ubuntu16:master__erlang18.3_gcc5.3.1_boost1.58.0_pugixml1.7
 
 
 publish_build_job:

--- a/config/Makefile.macros
+++ b/config/Makefile.macros
@@ -26,7 +26,7 @@ endif
 $(info OS Detected: $(CACTUS_OS))
 
 # Set which externals are built by default for each OS
-ifneq ($(CACTUS_OS), centos7)
+ifeq ($(CACTUS_OS), slc6)
     BUILD_ERLANG?=1
     BUILD_BOOST?=1
     BUILD_PUGIXML?=1

--- a/controlhub/rel/reltool.config
+++ b/controlhub/rel/reltool.config
@@ -28,6 +28,9 @@
        {excl_app_filters, ["\.gitignore"]},
        % crypto depends on openssl; exclude since not used and don't want dependency on openssl version
        {app, crypto, [{incl_cond, exclude}]},
+       % Stop hipe automatically being loaded due to dependency of standard libraries on hipe
+       % ('hipe' not required for ControlHub, but caused startup errors in some OS / Erlang releases)
+       {app, hipe, [{incl_cond, exclude}]},
        % Apps for lager syslog backend
        {app, syslog, [{mod_cond, app}, {incl_cond, include}, {lib_dir, "../deps/syslog"}]},
        {app, lager_syslog, [{mod_cond, app}, {incl_cond, include}, {lib_dir, "../deps/lager_syslog"}]},

--- a/controlhub/src/ch_device_client.erl
+++ b/controlhub/src/ch_device_client.erl
@@ -68,7 +68,7 @@
 
 -else.
 
--define(GET_MONOTONIC_TIME, erlang:monotonic_time(microsecond) ).
+-define(GET_MONOTONIC_TIME, erlang:monotonic_time(micro_seconds) ).
 -define(CALC_MONOTONIC_TIME_DIFF(T2,T1), (T2 - T1) ).
 
 -endif.

--- a/uhal/config/mfRules.mk
+++ b/uhal/config/mfRules.mk
@@ -73,7 +73,7 @@ ${PackagePath}/obj/%.o : ${PackagePath}/src/common/%.cxx  | ${PackagePath}/obj
 	
 # Main target: shared library
 ${LibraryTarget}: ${LibraryObjectFiles}  | ${PackagePath}/lib
-	${LD} -shared ${LDFLAGS} ${DependentLibraries} ${LibraryObjectFiles} -o $@
+	${LD} -shared ${LDFLAGS} ${LibraryObjectFiles} ${DependentLibraries} -o $@
 
 # Include automatically generated dependencies
 -include $(LibraryObjectFiles:.o=.d)

--- a/uhal/pycohal/Makefile
+++ b/uhal/pycohal/Makefile
@@ -40,10 +40,10 @@ LibraryPaths = \
 		${PYTHON_LIB_PREFIX}
 
 Libraries = \
-		pthread \
-		dl \
-		util \
-		${PYTHON_LIB} \
+		cactus_uhal_uhal \
+		cactus_uhal_log \
+		cactus_uhal_grammars \
+		${PUGIXML_LIB_NAME} \
 		\
 		boost_filesystem \
 		boost_python \
@@ -51,10 +51,9 @@ Libraries = \
 		boost_system \
 		boost_thread \
 		\
-		${PUGIXML_LIB_NAME} \
-		cactus_uhal_grammars \
-		cactus_uhal_log \
-		cactus_uhal_uhal
+		pthread \
+		dl \
+		util
 
 
 CXXFLAGS += -ftemplate-depth-128 -O0 -rdynamic -finline-functions -Wno-inline -DNDEBUG \


### PR DESCRIPTION
This PR is part of issue #65 ; changes include:
 * Automated build (but not test) jobs run on fedora26 and ubuntu16
 * By default, external packages now only built on SLC6
 * Fixes to uHAL & ControlHub compilation / runtime errors encountered on recent OSs (i.e. with recent gcc & Erlang versions)