### PR TITLE
uHAL : Add easily-understandable translation of info/error code values to log messages

### DIFF
--- a/uhal/uhal/include/uhal/ProtocolControlHub.hpp
+++ b/uhal/uhal/include/uhal/ProtocolControlHub.hpp
@@ -70,14 +70,8 @@ namespace uhal
     //! Exception class to handle the case where the target does not respond to the ControlHub
     UHAL_DEFINE_EXCEPTION_CLASS ( ControlHubTargetTimeout , "Exception class to handle the case where the target does not respond to the ControlHub" )
 
-    //! Exception class to handle the case where there in a timeout in communication between the processes running within the ControlHub
-    UHAL_DEFINE_EXCEPTION_CLASS ( ControlHubInternalTimeout , "Exception class to handle the case where there in a timeout in communication between the processes running within the ControlHub" )
-
-    //! Exception class to handle the case where the hardware sent a bad status packet to the ControlHub
-    UHAL_DEFINE_EXCEPTION_CLASS ( ControlHubReportedMalformedStatus , "Exception class to handle the case where the hardware sent a bad status packet to the ControlHub" )
-
-    //! Exception class to handle the case where the error code sent by the ControlHub is unknown to uHAL
-    UHAL_DEFINE_EXCEPTION_CLASS ( ControlHubUnknownErrorCode , "Exception class to handle the case where the error code sent by the ControlHub is unknown to uHAL" )
+    //! Exception class to handle cases in which the ControlHub returns a non-zero error code (excluding target timeouts)
+    UHAL_DEFINE_EXCEPTION_CLASS ( ControlHubErrorCodeSet, "Exception class to handle cases in which the ControlHub returns a non-zero error code (excluding target timeouts)" )
   }
 
   /**
@@ -159,6 +153,8 @@ namespace uhal
 
 
     private:
+      static void translateErrorCode(std::ostream& aStream, const uint16_t& aErrorCode);
+
       //! The IP address of the target device that is connected to the Control Hub
       uint32_t mDeviceIPaddress;
 

--- a/uhal/uhal/include/uhal/ProtocolIPbus.hpp
+++ b/uhal/uhal/include/uhal/ProtocolIPbus.hpp
@@ -164,6 +164,10 @@ namespace uhal
 
       virtual void dispatchExceptionHandler();
 
+  private:
+      boost::function<void (std::ostream&, const uint8_t&)> getInfoCodeTranslator() { return translateInfoCode; }
+
+      static void translateInfoCode(std::ostream& aStream, const uint8_t& aErrorCode);
       // std::vector< uint32_t > mSendPadding;
       // std::vector< uint32_t > mReplyPadding;
 
@@ -302,6 +306,10 @@ namespace uhal
       virtual void dispatchExceptionHandler();
 
     private:
+      boost::function<void (std::ostream&, const uint8_t&)> getInfoCodeTranslator() { return translateInfoCode; }
+
+      static void translateInfoCode(std::ostream& aStream, const uint8_t& aErrorCode);
+
       //! The transaction counter which will be incremented in the sent IPbus headers
       uint16_t mPacketCounter;
 

--- a/uhal/uhal/include/uhal/ProtocolIPbusCore.hpp
+++ b/uhal/uhal/include/uhal/ProtocolIPbusCore.hpp
@@ -42,6 +42,7 @@
 #include <deque>
 
 #include "boost/date_time/posix_time/posix_time_duration.hpp"
+#include "boost/function.hpp"
 
 #include "uhal/ClientInterface.hpp"
 
@@ -260,6 +261,8 @@ namespace uhal
 
     private:
 
+      virtual boost::function<void (std::ostream&, const uint8_t&)> getInfoCodeTranslator() = 0;
+
       //! The transaction counter which will be incremented in the sent IPbus headers
       uint32_t mTransactionCounter;
 
@@ -273,8 +276,37 @@ namespace uhal
   };
 
 
+  template<typename T>
+  struct TranslatedFmt {
+  public:
+    TranslatedFmt(const T& aData, const boost::function<void (std::ostream&, const T&)>& aFunction);
+    ~TranslatedFmt();
 
+    const T& mData;
+    const boost::function<void (std::ostream&, const T&)>& mFunc;
+  };
+
+  template <typename T>
+  TranslatedFmt<T>::TranslatedFmt(const T& aData, const boost::function<void (std::ostream&, const T&)>& aFunction) :
+    mData(aData),
+    mFunc(aFunction)
+  {
+  }
+
+  template <typename T>
+  TranslatedFmt<T>::~TranslatedFmt()
+  {
+  }
+
+  template <typename T>
+  std::ostream& operator<<(std::ostream& aStream, const TranslatedFmt<T>& aFmt)
+  {
+    aFmt.mFunc(aStream, aFmt.mData);
+    return aStream;
+  }
 }
+
+
 
 
 #endif

--- a/uhal/uhal/include/uhal/TemplateDefinitions/ProtocolIPbus.hxx
+++ b/uhal/uhal/include/uhal/TemplateDefinitions/ProtocolIPbus.hxx
@@ -207,6 +207,22 @@ namespace uhal
     IPbusCore::dispatchExceptionHandler();
   }
 
+  template< uint8_t IPbus_minor, uint32_t buffer_size>
+  void IPbus< 1 , IPbus_minor , buffer_size >::translateInfoCode(std::ostream& aStream, const uint8_t& aInfoCode) {
+    switch (aInfoCode) {
+      case 0:
+        aStream << "success";
+        break;
+      case 1:
+        aStream << "partial";
+        break;
+      case 2:
+        aStream << "failure";
+        break;
+      default:
+        aStream << "UNKNOWN";
+    }
+  }
   // --------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 
@@ -460,6 +476,36 @@ namespace uhal
 #endif
     mReceivePacketHeader.clear();
     IPbusCore::dispatchExceptionHandler();
+  }
+
+  template< uint8_t IPbus_minor , uint32_t buffer_size , bool BigEndianHack >
+  void IPbus< 2 , IPbus_minor , buffer_size , BigEndianHack >::translateInfoCode(std::ostream& aStream, const uint8_t& aInfoCode)
+  {
+    switch (aInfoCode) {
+      case 0:
+        aStream << "success";
+        break;
+      case 1:
+        aStream << "bad header";
+        break;
+      case 4:
+        aStream << "bus error on read";
+        break;
+      case 5:
+        aStream << "bus error on write";
+        break;
+      case 6:
+        aStream << "bus timeout on read";
+        break;
+      case 7:
+        aStream << "bus timeout on wite";
+        break;
+      case 0xf:
+        aStream << "outbound request";
+        break;
+      default:
+        aStream << "UNKNOWN";
+    }
   }
 
   // --------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/uhal/uhal/src/common/ProtocolIPbusCore.cpp
+++ b/uhal/uhal/src/common/ProtocolIPbusCore.cpp
@@ -203,7 +203,8 @@ namespace uhal
               " (ID = " , Integer ( lReplyTransactionId, IntFmt< hex , fixed >() ) ,
               ", type = " , lReplyIPbusTransactionType ,
               ", word count = " , Integer ( lReplyWordCount ) ,
-              ") has response field = " , Integer ( lReplyResponseGood, IntFmt< hex , fixed >() ) , " indicating an error (" ,
+              ") has response field = " , Integer ( lReplyResponseGood, IntFmt< hex , fixed >() ) ,
+              " = '", TranslatedFmt<uint8_t>(lReplyResponseGood, getInfoCodeTranslator()) , "' indicating an error (" ,
               Integer ( lNrReplyBytesValidated+1 ) , " bytes into IPbus reply payload)" );
         log ( *lExc , "Original sent header was ", Integer ( * ( ( uint32_t* ) ( aSendBufferStart ) ), IntFmt< hex , fixed >() ) ,
                       ", for base address ", Integer ( * ( ( uint32_t* ) ( aSendBufferStart+4 ) ), IntFmt< hex , fixed >() ), 


### PR DESCRIPTION
This pull request updates the error messages reporting non-success error/info code values so that they also state a short string describing the meaning of the info/error code value; addresses issue #76