### PR TITLE
First implementation of single-threaded client for IPbus over PCIe

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -211,6 +211,7 @@ publish_build_job:
     - uhal_test_suite.py -v -s "1.3 controlhub" ${TEST_SUITE_CONTROLHUB_PATH_ARGUMENT}
     - uhal_test_suite.py -v -s "2.0 udp"
     - uhal_test_suite.py -v -s "2.0 tcp"
+    - uhal_test_suite.py -v -s "2.0 pcie"
     - uhal_test_suite.py -v -s "2.0 controlhub - normal" ${TEST_SUITE_CONTROLHUB_PATH_ARGUMENT}
     - uhal_test_suite.py -v -s "2.0 controlhub - light packet loss" ${TEST_SUITE_CONTROLHUB_PATH_ARGUMENT}
 

--- a/uhal/grammars/src/common/URIGrammar.cpp
+++ b/uhal/grammars/src/common/URIGrammar.cpp
@@ -43,14 +43,14 @@ namespace grammars
     URIGrammar::base_type ( start )
   {
     using namespace boost::spirit;
-    start = protocol > hostname     > port         > - ( path ) > -( extension ) > - ( data_pairs_vector ); //EthernetURI | PCIeURI;
+    start = protocol > hostname     > - ( port )   > - ( path ) > -( extension ) > - ( data_pairs_vector ); //EthernetURI | PCIeURI;
 
     // EthernetURI = protocol > hostname     > port         > - ( path ) > -( extension ) > - ( data_pairs_vector );
     // PCIeURI     = protocol > empty_string > empty_string >  path      > empty_string   > - ( data_pairs_vector );
 
     protocol = + ( qi::char_ - qi::lit ( ":" ) ) > qi::lit ( "://" );
-    hostname = + ( qi::char_ - qi::lit ( ":" ) ) > qi::lit ( ":" );
-    port 	 = + ( qi::char_ - ascii::punct ) ;
+    hostname = + ( qi::char_ - qi::lit ( ":" ) ) ;
+    port 	 = qi::lit ( ":" ) > + ( qi::char_ - ascii::punct ) ;
     path 				= qi::lit ( "/" ) > + ( qi::char_ - qi::lit ( "." ) - qi::lit ( "?" ) );
     extension 			= qi::lit ( "." ) > + ( qi::char_ - qi::lit ( "?" ) ) ;
     data_pairs_vector 	= qi::lit ( "?" ) > *data_pairs;

--- a/uhal/tests/Makefile
+++ b/uhal/tests/Makefile
@@ -53,6 +53,7 @@ Libraries = \
 ExecutableLibraries = \
 		cactus_uhal_tests \
 		${Libraries} \
+		boost_chrono \
 		boost_regex \
 		boost_system \
 		${PUGIXML_LIB_NAME}

--- a/uhal/tests/etc/uhal/tests/dummy_connections.xml
+++ b/uhal/tests/etc/uhal/tests/dummy_connections.xml
@@ -24,6 +24,9 @@
 
   <connection id="dummy.controlhub2" uri="chtcp-2.0://localhost:10203?target=localhost:60001"	address_table="file://dummy_address.xml" />
   <connection id="dummy.docu.controlhub2" uri="chtcp-2.0://localhost:10203?target=localhost:60001"  address_table="file://docu_examples_address.xml" />
-  
+ 
+  <connection id="dummy.pcie2" uri="ipbuspcie-2.0:///tmp/uhal_pcie_client2device,/tmp/uhal_pcie_device2client" address_table="file://dummy_address.xml"/>
+  <connection id="dummy.docu.pcie2" uri="ipbuspcie-2.0:///tmp/uhal_pcie_client2device,/tmp/uhal_pcie_device2client" address_table="file://docu_examples_address.xml"/>
+
 </connections>
 

--- a/uhal/tests/include/uhal/tests/tools.hpp
+++ b/uhal/tests/include/uhal/tests/tools.hpp
@@ -43,9 +43,11 @@
 #include <exception>
 #include <sys/time.h>
 
+#include <boost/lexical_cast.hpp>
 #include <boost/thread/thread.hpp>
 
 #include "uhal/tests/UDPDummyHardware.hpp"
+#include "uhal/tests/PCIeDummyHardware.hpp"
 
 
 namespace uhal {
@@ -58,16 +60,17 @@ enum DeviceType {
   IPBUS_1_3_CONTROLHUB,
   IPBUS_2_0_UDP, 
   IPBUS_2_0_TCP,
-  IPBUS_2_0_CONTROLHUB
+  IPBUS_2_0_CONTROLHUB,
+  IPBUS_2_0_PCIE
 };
 
 
 struct DeviceInfo {
-  DeviceInfo(uhal::tests::DeviceType aType, uint16_t aPort, const std::string& aConnectionId);
+  DeviceInfo(uhal::tests::DeviceType aType, const std::string& aPort, const std::string& aConnectionId);
   ~DeviceInfo(){}
 
   DeviceType type;
-  uint16_t port;
+  std::string port;
 
   // ID for this device in unit test connection file
   std::string connectionId;
@@ -87,8 +90,8 @@ public:
 template <class DummyHardwareType>
 class DummyHardwareRunner : public DummyHardwareRunnerInterface {
 public:
-  DummyHardwareRunner(const uint16_t& aPort , const uint32_t& aReplyDelay, const bool& aBigEndianHack) :
-    mHw(aPort, aReplyDelay, aBigEndianHack),
+  DummyHardwareRunner(const std::string& aPort , const uint32_t& aReplyDelay, const bool& aBigEndianHack) :
+    mHw(boost::lexical_cast<uint16_t>(aPort), aReplyDelay, aBigEndianHack),
     mHwThread( boost::bind(&DummyHardwareType::run, &mHw))
   {
   }
@@ -108,6 +111,10 @@ private:
   DummyHardwareType mHw;
   boost::thread mHwThread;
 };
+
+
+template<>
+DummyHardwareRunner<PCIeDummyHardware>::DummyHardwareRunner(const std::string& aPort , const uint32_t& aReplyDelay, const bool& aBigEndianHack); 
 
 
 struct TestFixture {

--- a/uhal/tests/scripts/test_pycohal
+++ b/uhal/tests/scripts/test_pycohal
@@ -650,10 +650,11 @@ class TestMetaInfo(unittest.TestCase):
         """Run meta-info tests for ConnectionManager class."""
         devices_list = self.manager.getDevices()
         self.assertTrue( isinstance(devices_list, list) )
-        self.assertEqual( len(devices_list), 12 )
+        self.assertEqual( len(devices_list), 14 )
         self.assertEqual( devices_list, sorted(['dummy.udp','dummy.docu.udp','dummy.udp2','dummy.docu.udp2',
                                                 'dummy.tcp','dummy.docu.tcp','dummy.tcp2','dummy.docu.tcp2',
-                                                'dummy.controlhub','dummy.docu.controlhub', 'dummy.controlhub2', 'dummy.docu.controlhub2']) )
+                                                'dummy.controlhub','dummy.docu.controlhub', 'dummy.controlhub2', 'dummy.docu.controlhub2',
+                                                'dummy.pcie2', 'dummy.docu.pcie2']) )
         self.assertEqual( len(self.manager.getDevices(".*udp.*")), 4 )
         # Check for throw when try to create ConnectionManager from non-existant file
         self.assertRaises( uhal.exception, uhal.ConnectionManager, ("some_bad_invalid_string") )

--- a/uhal/tests/scripts/uhal_test_suite.py
+++ b/uhal/tests/scripts/uhal_test_suite.py
@@ -272,6 +272,10 @@ def get_commands(conn_file, controlhub_scripts_dir, uhal_tools_template_vhdl):
                controlhub_stop]
                 ]]
 
+    cmds += [["TEST IPBUS 2.0 PCIe",
+              ["run_unit_tests.exe -c %s -d 2.0-pcie --log_level=test_suite" % (conn_file)]
+            ]]
+
     cmds += [["TEST VALGRIND",
               [ # UDP 2
                "DummyHardwareUdp.exe --version 1 --port 50001",

--- a/uhal/tests/src/common/PCIeDummyHardware.cpp
+++ b/uhal/tests/src/common/PCIeDummyHardware.cpp
@@ -1,0 +1,293 @@
+/*
+---------------------------------------------------------------------------
+
+    This file is part of uHAL.
+
+    uHAL is a hardware access library and programming framework
+    originally developed for upgrades of the Level-1 trigger of the CMS
+    experiment at CERN.
+
+    uHAL is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    uHAL is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with uHAL.  If not, see <http://www.gnu.org/licenses/>.
+
+      Marc Magrans de Abril, CERN
+      email: marc.magrans.de.abril <AT> cern.ch
+
+      Andrew Rose, Imperial College, London
+      email: awr01 <AT> imperial.ac.uk
+
+      Tom Williams, Rutherford Appleton Laboratory, Oxfordshire
+      email: tom.williams <AT> cern.ch
+
+---------------------------------------------------------------------------
+*/
+
+#include "uhal/tests/PCIeDummyHardware.hpp"
+
+
+#include <errno.h>
+#include <fcntl.h>
+#include <pty.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#include <boost/lexical_cast.hpp>
+
+
+namespace uhal {
+namespace tests {
+
+PCIeDummyHardware::PCIeDummyHardware(const std::string& aDevicePathHostToFPGA, const std::string& aDevicePathFPGAToHost, const uint32_t& aReplyDelay, const bool& aBigEndianHack) :
+  DummyHardware<2, 0>(aReplyDelay, aBigEndianHack),
+  mDevicePathHostToFPGA(aDevicePathHostToFPGA),
+  mDevicePathFPGAToHost(aDevicePathFPGAToHost),
+  mNumberOfPages(1),
+  mWordsPerPage(360),
+  mNextPageIndex(0),
+  mPublishedPageCount(0),
+  mStop(false),
+  mDeviceFileHostToFPGA(-1),
+  mDeviceFileFPGAToHost(-1)
+{
+  log(Debug(), "PCIe dummy hardware is creating client-to-device named PIPE ", Quote (mDevicePathHostToFPGA));
+  int rc = mkfifo(mDevicePathHostToFPGA.c_str(), 0666);
+  if ( rc != 0 ) {
+    std::runtime_error lExc("Cannot create FIFO; mkfifo returned " + boost::lexical_cast<std::string>(rc) + ", errno=" + boost::lexical_cast<std::string>(errno));
+    throw lExc;
+  }
+
+  mDeviceFileHostToFPGA = open(mDevicePathHostToFPGA.c_str(), O_RDONLY | O_NONBLOCK); /* O_NONBLOCK so that open does not hang */
+  if ( mDeviceFileHostToFPGA < 0 ) {
+    std::runtime_error lExc("Problem opening host-to-FPGA device file '" + mDevicePathHostToFPGA + "', errno=" + boost::lexical_cast<std::string>(errno) + " (dummy hw)");
+    throw lExc;
+  }
+
+  // Set the new flags with O_NONBLOCK masked out
+  int lFileFlags = fcntl(mDeviceFileHostToFPGA, F_GETFL);
+  fcntl(mDeviceFileHostToFPGA, F_SETFL, lFileFlags & ~O_NONBLOCK);
+
+  log(Debug(), "PCIe dummy hardware is creating device-to-client file ", Quote (mDevicePathFPGAToHost));
+  mDeviceFileFPGAToHost = open(mDevicePathFPGAToHost.c_str(), O_RDWR | O_CREAT | O_DIRECTORY, 0666 /* permission */);
+  if ( mDeviceFileFPGAToHost < 0 ) {
+    std::runtime_error lExc("Cannot open FPGA-to-host device file '" + mDevicePathFPGAToHost + "' (dummy hw)");
+    throw lExc;
+  }
+
+  std::vector<uint32_t> lFPGAToHostData(4 + mNumberOfPages * mWordsPerPage, 0);
+  lFPGAToHostData.at(0) = mNumberOfPages;
+  lFPGAToHostData.at(1) = mWordsPerPage;
+  lFPGAToHostData.at(2) = mNumberOfPages;
+  lFPGAToHostData.at(2) = mNumberOfPages;
+
+  dmaWrite(mDeviceFileFPGAToHost, 0, lFPGAToHostData);
+
+  log(Notice(), "Starting IPbus 2.0 PCIe dummy hardware ", Quote(mDevicePathHostToFPGA), ", ", Quote(mDevicePathFPGAToHost), "; ", Integer(mNumberOfPages), " pages, ", Integer(mWordsPerPage), " words per page");
+}
+
+
+PCIeDummyHardware::~PCIeDummyHardware()
+{
+  log(Notice(), "Destroying IPbus 2.0 PCIe dummy hardware ", Quote(mDevicePathHostToFPGA), ", ", Quote(mDevicePathFPGAToHost));
+
+  if (close(mDeviceFileHostToFPGA))
+    log(Fatal(), "Problem occurred when closing ", Quote(mDevicePathHostToFPGA), " during dummy hardware destruction");
+  if (remove(mDevicePathHostToFPGA.c_str()))
+    log(Fatal(), "Problem occurred when removing ", Quote(mDevicePathHostToFPGA), " during dummy hardware destruction");
+
+  if (close(mDeviceFileFPGAToHost))
+    log(Fatal(), "Problem occurred when closing ", Quote(mDevicePathFPGAToHost), " during dummy hardware destruction");
+  if (remove(mDevicePathFPGAToHost.c_str()))
+    log(Fatal(), "Problem occurred when removing ", Quote(mDevicePathFPGAToHost), " during dummy hardware destruction");
+}
+
+
+void PCIeDummyHardware::run()
+{
+  log(Info(), "Entering run method for IPbus 2.0 PCIe dummy hardware ", Quote(mDevicePathHostToFPGA), ", ", Quote(mDevicePathFPGAToHost));
+
+  while ( !mStop ) {
+    fd_set lInputFileSet;
+    FD_ZERO(&lInputFileSet);
+    FD_SET(mDeviceFileHostToFPGA, &lInputFileSet);
+
+    timeval lTimeout;
+    lTimeout.tv_sec = 0;
+    lTimeout.tv_usec = 50000;
+    int rc = select(FD_SETSIZE, &lInputFileSet, NULL, NULL, &lTimeout);
+    log (Debug(), "PCIeDummyHardware::run  -  select returns ", Integer(rc), " Input file set ", (FD_ISSET(mDeviceFileHostToFPGA, &lInputFileSet) ? "contains" : "does not contain"),  " pty");
+
+    if (rc == 0)
+      continue;
+
+    log(Debug(), "IPbus 2.0 PCIe dummy hardware ", Quote(mDevicePathHostToFPGA), ", ", Quote(mDevicePathFPGAToHost), " : data ready; reading 'packet length' header");
+    // FIXME: Define template method that reads sizeof(T) bytes and returns T
+    std::vector<uint32_t> lPageHeader;
+    dmaBlockingRead(mDeviceFileHostToFPGA, 0x0, 1, lPageHeader);
+
+    if (lPageHeader.at(0) >= mWordsPerPage) {
+      log(Fatal(), "PCIeDummyHardware::run  -  returning early since receiving ", Integer(lPageHeader.at(0)), "-word packet, but there's only ", Integer(mWordsPerPage), " words per page");
+      return;
+    }
+
+    log(Info(), "IPbus 2.0 PCIe dummy hardware ", Quote(mDevicePathHostToFPGA), ", ", Quote(mDevicePathFPGAToHost), " : reading ", Integer(lPageHeader.at(0)), "-word packet");
+    mReceive.clear();
+    dmaBlockingRead(mDeviceFileHostToFPGA, 0x0, lPageHeader.at(0), mReceive);
+
+    // std::cout << "Received:" << std::endl;
+    // for(size_t i=0; i<mReceive.size(); i++)
+    //   std::cout  << " @" << i << "   0x" << std::hex << mReceive.at(i) << std::dec << std::endl;
+
+    mReply.clear();
+    AnalyzeReceivedAndCreateReply(4 * lPageHeader.at(0));
+
+    log(Info(), "IPbus 2.0 PCIe dummy hardware ", Quote(mDevicePathHostToFPGA), ", ", Quote(mDevicePathFPGAToHost), " : writing ", Integer(mReply.size()), "-word reply to page ", Integer(mNextPageIndex));
+    lPageHeader.clear();
+    lPageHeader.push_back(mReply.size());
+
+    dmaWrite(mDeviceFileFPGAToHost, 4 + mNextPageIndex * mWordsPerPage, lPageHeader); // FIXME: Define template dmaWrite method that takes const T& as final argument, so that don't have to define vector
+    dmaWrite(mDeviceFileFPGAToHost, 4 + mNextPageIndex * mWordsPerPage + 1, mReply);
+
+    std::vector<uint32_t> lData;
+    lData.push_back(mPublishedPageCount+1); // FIXME: Define template dmaWrite method that takes const T& as final argument, so that don't have to define vector
+    dmaWrite(mDeviceFileFPGAToHost, 3, lData);
+
+    mNextPageIndex = (mNextPageIndex + 1) % mNumberOfPages;
+    mPublishedPageCount++;
+  }
+
+  log(Info(), "Exiting run method for IPbus 2.0 PCIe dummy hardware ", Quote(mDevicePathHostToFPGA), ", ", Quote(mDevicePathFPGAToHost));
+}
+
+
+void PCIeDummyHardware::stop()
+{
+  log(Info(), "Stopping IPbus 2.0 PCIe dummy hardware ", Quote(mDevicePathHostToFPGA), ", ", Quote(mDevicePathFPGAToHost));
+  mStop = true;
+}
+
+
+void PCIeDummyHardware::dmaRead(int aFileDescriptor, const uint32_t aAddr, const uint32_t aNrWords, std::vector<uint32_t>& aValues)
+{
+  char *allocated = NULL;
+  posix_memalign((void **)&allocated, 4096/*alignment*/, 4*aNrWords + 4096);
+  assert(allocated);
+
+  /* select AXI MM address */
+  char* buffer = allocated;
+  off_t off = lseek(aFileDescriptor, 4*aAddr, SEEK_SET);
+
+  /* read data from AXI MM into buffer using SGDMA */
+  int rc = ::read(aFileDescriptor, buffer, 4*aNrWords);
+  assert(rc >= 0);
+  if ((rc % 4) != 0)
+    log(Fatal(), "PCIeDummyHardware::dmaRead  -  rc = ", Integer(rc));
+  assert((rc % 4) == 0);
+  if ((rc > 0) && (rc < 4*aNrWords)) {
+    std::cout << "Short read of " << rc << " bytes into a " << 4*aNrWords << " bytes buffer, could be a packet read?\n";
+  }
+
+  aValues.insert(aValues.end(), reinterpret_cast<uint32_t*>(buffer), reinterpret_cast<uint32_t*>(buffer)+ aNrWords);
+//    for (unsigned i=0; i<aNrWords; i++) {
+//      //uint32_t val = (buffer[4*i]&0xff)+((buffer[4*i+1]&0xff)<<8)+((buffer[4*i+2]&0xff)<<16)
+//      //  +((buffer[4*i+3]&0xff)<<24);
+//      uint32_t val = *reinterpret_cast<uint32_t*>(buffer);
+//      printf("ipbus address : 0x%08x\n", aAddr);
+//      printf("readback value: 0x%08x\n\n",val);
+//    }
+
+  free(allocated);
+}
+
+
+void PCIeDummyHardware::dmaBlockingRead(int aFileDescriptor, const uint32_t aAddr, const uint32_t aNrWords, std::vector<uint32_t>& aValues)
+{
+  char *allocated = NULL;
+  posix_memalign((void **)&allocated, 4096/*alignment*/, 4*aNrWords + 4096);
+  assert(allocated);
+
+  /* select AXI MM address */
+  char* buffer = allocated;
+  off_t off = lseek(aFileDescriptor, 4*aAddr, SEEK_SET);
+
+  memset(buffer, 0, 4 * aNrWords);
+
+  /* read data from AXI MM into buffer using SGDMA */
+  int lNrBytesRead = 0;
+  do {
+    if (lNrBytesRead != 0)
+      log (Fatal(), "dmaBlockingRead calling ::read multiple times to get all expected ", Integer(aNrWords * 4), " bytes (only ", Integer(lNrBytesRead), " so far)");
+    int rc = ::read(aFileDescriptor, buffer + lNrBytesRead, 4*aNrWords - lNrBytesRead);
+    if (rc <= 0)
+      log (Fatal(), "dmaBlockingRead   -   read returned ", Integer(rc), ", bugger! errno = ", Integer(errno));
+    assert (rc > 0);
+    lNrBytesRead += rc;
+  } while (lNrBytesRead < (4 * aNrWords) );
+  if (lNrBytesRead > (4 * aNrWords))
+    log (Fatal(), "dmaBlockingRead   -   read ", Integer(lNrBytesRead), " but only wanted to read  ", Integer(aNrWords * 4), " bytes");
+  // int rc = ::read(aFileDescriptor, buffer, 4*aNrWords);
+  // assert(rc >= 0);
+  // if ((rc % 4) != 0)
+  //   log(Fatal(), "PCIeDummyHardware::dmaRead  -  rc = ", rc); 
+  // assert((rc % 4) == 0);
+  // if ((rc > 0) && (rc < 4*aNrWords)) {
+  //   std::cout << "Short read of " << rc << " bytes into a " << 4*aNrWords << " bytes buffer, could be a packet read?\n";
+  // }
+
+  aValues.insert(aValues.end(), reinterpret_cast<uint32_t*>(buffer), reinterpret_cast<uint32_t*>(buffer)+ aNrWords);
+//    for (unsigned i=0; i<aNrWords; i++) {
+//      //uint32_t val = (buffer[4*i]&0xff)+((buffer[4*i+1]&0xff)<<8)+((buffer[4*i+2]&0xff)<<16)
+//      //  +((buffer[4*i+3]&0xff)<<24);
+//      uint32_t val = *reinterpret_cast<uint32_t*>(buffer);
+//      printf("ipbus address : 0x%08x\n", aAddr);
+//      printf("readback value: 0x%08x\n\n",val);
+//    }
+
+  free(allocated);
+}
+
+
+
+bool PCIeDummyHardware::dmaWrite(int aFileDescriptor, const uint32_t aAddr, const std::vector<uint32_t>& aValues) 
+{
+  return dmaWrite(aFileDescriptor, aAddr, reinterpret_cast<const uint8_t*>(aValues.data()), 4 * aValues.size());
+}
+
+
+bool PCIeDummyHardware::dmaWrite(int aFileDescriptor, const uint32_t aAddr, const uint8_t* const aPtr, const size_t aNrBytes) 
+{
+  assert((aNrBytes % 4) == 0);
+
+  char *allocated = NULL;
+  posix_memalign((void **)&allocated, 4096/*alignment*/, aNrBytes + 4096);
+  assert(allocated);
+
+  // data to write to register address
+  char* buffer = allocated;
+  memcpy(buffer, aPtr, aNrBytes);
+
+  /* select AXI MM address */
+  off_t off = lseek(aFileDescriptor, 4*aAddr, SEEK_SET);
+
+  /* write buffer to AXI MM address using SGDMA */
+  int rc = ::write(aFileDescriptor, buffer, aNrBytes);
+  assert(rc == aNrBytes);
+
+  free(allocated);
+
+  return true;
+}
+
+
+} // end ns tests
+} // end ns uhal

--- a/uhal/tests/src/common/PerfTester_static.cpp
+++ b/uhal/tests/src/common/PerfTester_static.cpp
@@ -214,7 +214,7 @@ bool uhal::tests::PerfTester::validation_test_write_rmwbits_read ( ClientInterfa
 
   oss_values << "Wrote value 0x" << std::hex << x0 << ", then did RMW-bits with AND-term 0x" << a << ", OR-term 0x" << b;
 
-  const bool ipbus2 = ( ( c.uri().find ( "ipbusudp-2.0" ) != string::npos ) || ( c.uri().find ( "ipbustcp-2.0" ) != string::npos ) || ( c.uri().find ( "chtcp-2.0" ) != string::npos ) );
+  const bool ipbus2 = ( ( c.uri().find ( "ipbusudp-2.0" ) != string::npos ) || ( c.uri().find ( "ipbustcp-2.0" ) != string::npos ) || ( c.uri().find ( "chtcp-2.0" ) != string::npos ) || ( c.uri().find ( "ipbuspcie-2.0" ) != string::npos ) );
 
   try
   {
@@ -273,7 +273,7 @@ bool uhal::tests::PerfTester::validation_test_write_rmwsum_read ( ClientInterfac
 
   oss_values << "Wrote value 0x" << std::hex << x0 << ", then did RMW-sum with ADDEND 0x" << a;
 
-  const bool ipbus2 = ( ( c.uri().find ( "ipbusudp-2.0" ) != string::npos ) || ( c.uri().find ( "ipbustcp-2.0" ) != string::npos ) || ( c.uri().find ( "chtcp-2.0" ) != string::npos ) );
+  const bool ipbus2 = ( ( c.uri().find ( "ipbusudp-2.0" ) != string::npos ) || ( c.uri().find ( "ipbustcp-2.0" ) != string::npos ) || ( c.uri().find ( "chtcp-2.0" ) != string::npos )  || ( c.uri().find ( "ipbuspcie-2.0" ) != string::npos ) || ( c.uri().find ( "ipbuspcie-2.0" ) != string::npos ) );
 
   try
   {

--- a/uhal/tests/src/common/run_unit_tests.cxx
+++ b/uhal/tests/src/common/run_unit_tests.cxx
@@ -62,12 +62,13 @@ std::map<std::string, DeviceInfo> getDeviceMap()
 {
   std::map<std::string, DeviceInfo> lResult;
 
-  lResult.insert(std::make_pair(std::string("1.3-udp"), DeviceInfo(IPBUS_1_3_UDP, 50001, "dummy.udp")));
-  lResult.insert(std::make_pair(std::string("1.3-tcp"), DeviceInfo(IPBUS_1_3_TCP, 50002, "dummy.tcp")));
-  lResult.insert(std::make_pair(std::string("1.3-hub"), DeviceInfo(IPBUS_1_3_CONTROLHUB, 50001, "dummy.controlhub")));
-  lResult.insert(std::make_pair(std::string("2.0-udp"), DeviceInfo(IPBUS_2_0_UDP, 60001, "dummy.udp2")));
-  lResult.insert(std::make_pair(std::string("2.0-tcp"), DeviceInfo(IPBUS_2_0_TCP, 60002, "dummy.tcp2")));
-  lResult.insert(std::make_pair(std::string("2.0-hub"), DeviceInfo(IPBUS_2_0_CONTROLHUB, 60001, "dummy.controlhub2")));
+  lResult.insert(std::make_pair(std::string("1.3-udp"), DeviceInfo(IPBUS_1_3_UDP, "50001", "dummy.udp")));
+  lResult.insert(std::make_pair(std::string("1.3-tcp"), DeviceInfo(IPBUS_1_3_TCP, "50002", "dummy.tcp")));
+  lResult.insert(std::make_pair(std::string("1.3-hub"), DeviceInfo(IPBUS_1_3_CONTROLHUB, "50001", "dummy.controlhub")));
+  lResult.insert(std::make_pair(std::string("2.0-udp"), DeviceInfo(IPBUS_2_0_UDP, "60001", "dummy.udp2")));
+  lResult.insert(std::make_pair(std::string("2.0-tcp"), DeviceInfo(IPBUS_2_0_TCP, "60002", "dummy.tcp2")));
+  lResult.insert(std::make_pair(std::string("2.0-hub"), DeviceInfo(IPBUS_2_0_CONTROLHUB, "60001", "dummy.controlhub2")));
+  lResult.insert(std::make_pair(std::string("2.0-pcie"), DeviceInfo(IPBUS_2_0_PCIE, "/tmp/uhal_pcie_client2device,/tmp/uhal_pcie_device2client", "dummy.pcie2")));
 
   return lResult;
 }

--- a/uhal/tests/src/common/test_multithreaded.cpp
+++ b/uhal/tests/src/common/test_multithreaded.cpp
@@ -98,24 +98,29 @@ void job_multiple ( const std::string& connection, const std::string& id )
 
 BOOST_FIXTURE_TEST_CASE(multiple_hwinterfaces, TestFixture)
 {
-  std::vector<boost::thread*> jobs;
-
-  for ( size_t i=0; i!=N_THREADS; ++i )
+  if (sDeviceInfo.type != IPBUS_2_0_PCIE)
   {
-    log ( Warning() , ThisLocation() , ":" , Integer ( i ) );
-    jobs.push_back ( new boost::thread ( job_multiple, sConnectionFile, sDeviceId ) );
-  }
+    std::vector<boost::thread*> jobs;
 
-  for ( size_t i=0; i!=N_THREADS; ++i )
-  {
-    log ( Warning() , ThisLocation() , ":" , Integer ( i ) );
-    //boost::posix_time::time_duration timeout = boost::posix_time::seconds ( TIMEOUT_S );
-    //CACTUS_CHECK ( jobs[i]->timed_join ( timeout ) );
-    jobs[i]->join();
-    delete jobs[i];
-  }
+    for ( size_t i=0; i!=N_THREADS; ++i )
+    {
+      log ( Warning() , ThisLocation() , ":" , Integer ( i ) );
+      jobs.push_back ( new boost::thread ( job_multiple, sConnectionFile, sDeviceId ) );
+    }
 
-  log ( Warning() , ThisLocation() );
+    for ( size_t i=0; i!=N_THREADS; ++i )
+    {
+      log ( Warning() , ThisLocation() , ":" , Integer ( i ) );
+      //boost::posix_time::time_duration timeout = boost::posix_time::seconds ( TIMEOUT_S );
+      //CACTUS_CHECK ( jobs[i]->timed_join ( timeout ) );
+      jobs[i]->join();
+      delete jobs[i];
+    }
+
+    log ( Warning() , ThisLocation() );  
+  }
+  else
+    std::cout << "  **  Skipping multiple HwInterface test for PCIe  **" << std::endl;
 }
 
 

--- a/uhal/tests/src/common/test_nonreachable.cpp
+++ b/uhal/tests/src/common/test_nonreachable.cpp
@@ -36,6 +36,7 @@
 
 #include "uhal/ProtocolUDP.hpp"
 #include "uhal/ProtocolTCP.hpp"
+#include "uhal/ProtocolPCIe.hpp"
 #include "uhal/ProtocolControlHub.hpp"
 
 #include "uhal/tests/tools.hpp"
@@ -63,6 +64,10 @@ BOOST_AUTO_TEST_CASE(check_nonreachable_device)
     if ( hw.uri().find ( "ipbustcp" ) != std::string::npos )
     {
       BOOST_CHECK_THROW ( { hw.getNode ( "REG" ).read();  hw.dispatch(); } , uhal::exception::TransportLayerError );
+    }
+    else if ( hw.uri().find ( "ipbuspcie" ) != std::string::npos )
+    {
+      BOOST_CHECK_THROW ( { hw.getNode ( "REG" ).read();  hw.dispatch(); } , uhal::exception::PCIeInitialisationError );
     }
     else
     {

--- a/uhal/tests/src/common/tools.cpp
+++ b/uhal/tests/src/common/tools.cpp
@@ -51,10 +51,18 @@ namespace uhal {
 namespace tests {
 
 
-DeviceInfo::DeviceInfo(uhal::tests::DeviceType aType, uint16_t aPort, const std::string& aConnectionId) : 
+DeviceInfo::DeviceInfo(uhal::tests::DeviceType aType, const std::string& aPort, const std::string& aConnectionId) : 
   type(aType),
   port(aPort),
   connectionId(aConnectionId)
+{
+}
+
+
+template<>
+DummyHardwareRunner<PCIeDummyHardware>::DummyHardwareRunner(const std::string& aPort , const uint32_t& aReplyDelay, const bool& aBigEndianHack) : 
+  mHw(aPort.substr(0, aPort.find(",")), aPort.substr(aPort.find(",")+1), aReplyDelay, aBigEndianHack),
+  mHwThread( boost::bind(&PCIeDummyHardware::run, &mHw))
 {
 }
 
@@ -100,6 +108,9 @@ boost::shared_ptr<DummyHardwareRunnerInterface> TestFixture::createRunner (const
     case IPBUS_2_0_TCP :
       lResult.reset(new DummyHardwareRunner<TCPDummyHardware<2,0> >(aDetails.port, 0, false));
       break;
+    case IPBUS_2_0_PCIE : 
+      lResult.reset(new DummyHardwareRunner<PCIeDummyHardware>(aDetails.port, 0, false));
+      break;
   }
 
   return lResult;
@@ -107,7 +118,7 @@ boost::shared_ptr<DummyHardwareRunnerInterface> TestFixture::createRunner (const
 
 
 std::string TestFixture::sConnectionFile = "";
-DeviceInfo TestFixture::sDeviceInfo(IPBUS_2_0_UDP, 60001, "dummy.udp2");
+DeviceInfo TestFixture::sDeviceInfo(IPBUS_2_0_UDP, "60001", "dummy.udp2");
 std::string TestFixture::sDeviceId = "";
 
 

--- a/uhal/uhal/Makefile
+++ b/uhal/uhal/Makefile
@@ -41,6 +41,7 @@ Libraries = pthread \
 		boost_filesystem \
 		boost_regex \
 		boost_thread \
+		boost_chrono \
 		\
 		cactus_uhal_grammars \
 		cactus_uhal_log	

--- a/uhal/uhal/include/uhal/ProtocolPCIe.hpp
+++ b/uhal/uhal/include/uhal/ProtocolPCIe.hpp
@@ -27,46 +27,48 @@
       Marc Magrans de Abril, CERN
       email: marc.magrans.de.abril <AT> cern.ch
 
+      Tom Williams, Rutherford Appleton Laboratory, Oxfordshire
+      email: tom.williams <AT> cern.ch
+
 ---------------------------------------------------------------------------
 */
 
 /**
 	@file
-	@author Andrew W. Rose
-	@date 2012
+	@author Tom Williams
+	@date September 2017
 */
 
 #ifndef _uhal_ProtocolPCIe_hpp_
 #define _uhal_ProtocolPCIe_hpp_
 
-#include "uhal/ClientInterface.hpp"
-#include "uhal/log/exception.hpp"
-#include "uhal/log/log.hpp"
 
 #include <iostream>
 #include <iomanip>
+#include <string>
 
 #include <boost/shared_ptr.hpp>
 
-#include <string>
+#include "uhal/ClientInterface.hpp"
+#include "uhal/log/exception.hpp"
+#include "uhal/ProtocolIPbus.hpp"
+
 
 namespace uhal
 {
 
   namespace exception
   {
-    //! Exceptions get defined here
-    // UHAL_DEFINE_EXCEPTION_CLASS ( UdpTimeout , "Exception class to handle the case where the PCIe connection timed out." )
+    //! Exception class to handle the case in which the PCIe connection timed out.
+    UHAL_DEFINE_DERIVED_EXCEPTION_CLASS ( PCIeTimeout , ClientTimeout , "Exception class to handle the case in which the PCIe connection timed out." )
+    //! Exception class to handle a failure to read from the specified device files during initialisation
+    UHAL_DEFINE_EXCEPTION_CLASS ( PCIeInitialisationError , "Exception class to handle a failure to read from the specified device files during initialisation." )
   }
 
   //! Transport protocol to transfer an IPbus buffer via PCIe
-  template < typename InnerProtocol >
-  class PCIe : public InnerProtocol
+  class PCIe : public IPbus< 2 , 0 >
   {
-
     public:
-      //! Functor class to perform the actual transport, Like this to allow multithreading if desirable.
-
       /**
       	Constructor
       	@param aId the uinique identifier that the client will be given.
@@ -74,26 +76,22 @@ namespace uhal
       */
       PCIe ( const std::string& aId, const URI& aUri );
 
-      /**
-        Copy Constructor
-        This creates a new socket, dispatch queue, dispatch thread, etc. which connects to the same target ip/port
-        @param aPCIe a PCIe-protocol object to copy
-      */
+    private:
       PCIe ( const PCIe& aPCIe );
 
       /**
        Assignment operator
        This reassigns the endpoint, closes the existing socket and cleans up the buffers, etc. On the next call which requires the socket, it will be reopened with the new endpoint.
-       @param aPCIe a PCIe-protocol object to copy
+       @param aUDP a UDP-protocol object to copy
        @return reference to the current object to allow chaining of assignments
             */
       PCIe& operator= ( const PCIe& aPCIe );
 
-
-      /**
-      	Destructor
-      */
+    public:
+      //!	Destructor
       virtual ~PCIe();
+
+    protected:
 
       /**
       	Send the IPbus buffer to the target, read back the response and call the packing-protocol's validate function
@@ -108,36 +106,75 @@ namespace uhal
       virtual void Flush( );
 
 
-    protected:
-      /**
-        Function which tidies up this protocol layer in the event of an exception
-       */
+      //! Function which tidies up this protocol layer in the event of an exception
       virtual void dispatchExceptionHandler();
 
 
     private:
-      /**
-        Initialize performing the next PCIe write operation
-      */
-      void write ( );
+
+      typedef IPbus< 2 , 0 > InnerProtocol;
+
+      typedef boost::chrono::steady_clock SteadyClock_t;
 
       /**
-        Initialize performing the next PCIe read operation
+        Return the maximum size to be sent based on the buffer size in the target
+        @return the maximum size to be sent
       */
-      void read ( );
+      uint32_t getMaxSendSize();
 
-    private:
+      /**
+        Return the maximum size of reply packet based on the buffer size in the target
+        @return the maximum size of reply packet
+      */
+      uint32_t getMaxReplySize();
 
-      //! The send operation currently in progress
-      boost::shared_ptr< Buffers > mDispatchBuffers;
-      //! The receive operation currently in progress or the next to be done
-      boost::shared_ptr< Buffers > mReplyBuffers;
+      //! Set up the connection to the device
+      void connect();
 
+      //! Close the connection to the device
+      void disconnect();
+
+      //! Write request packet to next page in host-to-FPGA device file 
+      void write(const boost::shared_ptr<Buffers>& aBuffers);
+
+      //! Read next pending reply packet appropriate page of FPGA-to-host device file, and validate contents
+      void read();
+
+
+      static void dmaRead(int aFileDescriptor, const uint32_t aAddr, const uint32_t aNrWords, std::vector<uint32_t>& aValues);
+
+
+      static bool dmaWrite(int aFileDescriptor, const uint32_t aAddr, const std::vector<uint32_t>& aValues);
+
+      static bool dmaWrite(int aFileDescriptor, const uint32_t aAddr, const uint8_t* const aPtr, const size_t aNrBytes);
+
+      static bool dmaWrite(int aFileDescriptor, const uint32_t aAddr, const std::vector<std::pair<const uint8_t*, size_t> >& aData);
+
+      //! Host-to-FPGA device file path
+      std::string mDevicePathHostToFPGA;
+      //! FPGA-to-host device file path
+      std::string mDevicePathFPGAToHost;
+
+      //! File desriptor for host-to-FPGA device file
+      int mDeviceFileHostToFPGA;
+      //! File descriptor for FPGA-to-host device file
+      int mDeviceFileFPGAToHost;
+
+
+      uint32_t mNumberOfPages, mPageSize, mIndexNextPage, mPublishedReplyPageCount;
+
+      //! The list of buffers still awaiting a reply
+      std::deque < boost::shared_ptr< Buffers > > mReplyQueue;
+
+      /**
+        A pointer to an exception object for passing exceptions from the worker thread to the main thread.
+        Exceptions must always be created on the heap (i.e. using `new`) and deletion will be handled in the main thread
+      */
+      uhal::exception::exception* mAsynchronousException;
   };
 
 
 }
 
-#include "uhal/TemplateDefinitions/ProtocolPCIe.hxx"
 
 #endif

--- a/uhal/uhal/src/common/ClientFactory.cpp
+++ b/uhal/uhal/src/common/ClientFactory.cpp
@@ -62,7 +62,7 @@ namespace uhal
       mInstance->add< TCP< ControlHub < IPbus< 1 , 3 > > , 3 > > ( "chtcp-1.3", "Hardware access via the Control Hub, using IPbus version 1.3" );
       mInstance->add< TCP< ControlHub < IPbus< 2 , 0 > > , 3 > > ( "chtcp-2.0", "Hardware access via the Control Hub, using IPbus version 2.0" );
       // ---------------------------------------------------------------------
-//      mInstance->add< PCIe< IPbus< 2 , 0 , 48000 > > > ( "pcie-2.0" , "Direct access to hardware via PCIe, using IPbus version 2.0" );
+      mInstance->add< PCIe > ( "ipbuspcie-2.0" , "Direct access to hardware via PCIe, using IPbus version 2.0" );
       // ---------------------------------------------------------------------
 
     }

--- a/uhal/uhal/src/common/ClientInterface.cpp
+++ b/uhal/uhal/src/common/ClientInterface.cpp
@@ -140,7 +140,9 @@ namespace uhal
   {
     std::stringstream lReturn;
     // url is always of the form "protocol://hostname:port"
-    lReturn << mUri.mProtocol << "://" << mUri.mHostname << ":" << mUri.mPort;
+    lReturn << mUri.mProtocol << "://" << mUri.mHostname;
+    if ( !mUri.mPort.empty() )
+      lReturn << ":" << mUri.mPort;
 
     // there is sometimes a path
     if ( mUri.mPath != "" )

--- a/uhal/uhal/src/common/ProtocolPCIe.cpp
+++ b/uhal/uhal/src/common/ProtocolPCIe.cpp
@@ -1,0 +1,397 @@
+/*
+---------------------------------------------------------------------------
+
+    This file is part of uHAL.
+
+    uHAL is a hardware access library and programming framework
+    originally developed for upgrades of the Level-1 trigger of the CMS
+    experiment at CERN.
+
+    uHAL is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    uHAL is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with uHAL.  If not, see <http://www.gnu.org/licenses/>.
+
+
+      Andrew Rose, Imperial College, London
+      email: awr01 <AT> imperial.ac.uk
+
+      Marc Magrans de Abril, CERN
+      email: marc.magrans.de.abril <AT> cern.ch
+
+      Tom Williams, Rutherford Appleton Laboratory, Oxfordshire
+      email: tom.williams <AT> cern.ch
+
+---------------------------------------------------------------------------
+*/
+
+/**
+	@file
+	@author Tom Williams
+	@date September 2017
+*/
+
+#include "uhal/ProtocolPCIe.hpp"
+
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <boost/thread/thread.hpp>
+
+#include "uhal/Buffers.hpp"
+#include "uhal/log/log.hpp"
+
+
+namespace uhal {
+
+PCIe::PCIe ( const std::string& aId, const URI& aUri ) :
+  IPbus< 2 , 0 > ( aId , aUri ),
+  mDevicePathHostToFPGA(aUri.mHostname.substr(0, aUri.mHostname.find(","))),
+  mDevicePathFPGAToHost(aUri.mHostname.substr(aUri.mHostname.find(",")+1)),
+  mDeviceFileHostToFPGA(-1),
+  mDeviceFileFPGAToHost(-1),
+  mNumberOfPages(0),
+  mPageSize(0),
+  mIndexNextPage(0),
+  mPublishedReplyPageCount(0),
+  mAsynchronousException ( NULL )
+{
+  if ( aUri.mHostname.find(",") == std::string::npos ) {
+    exception::PCIeInitialisationError lExc;
+    log(lExc, "No comma found in hostname of PCIe client URI '" + uri() + "'; cannot construct 2 paths for device files");
+    throw lExc;
+  }
+  else if ( aUri.mHostname.find(",") == 0 || aUri.mHostname.find(",") == aUri.mHostname.size()-1) {
+    exception::PCIeInitialisationError lExc;
+    log(lExc, "Hostname of PCIe client URI '" + uri() + "' starts/ends with a comma; cannot construct 2 paths for device files");
+    throw lExc;
+  }
+}
+
+
+PCIe::~PCIe()
+{
+  disconnect();
+}
+
+
+void PCIe::implementDispatch ( boost::shared_ptr< Buffers > aBuffers )
+{
+  log(Debug(), "PCIe client (URI: ", Quote(uri()), ") : implementDispatch method called");
+
+  if ( (mDeviceFileFPGAToHost < 0) && (mDeviceFileHostToFPGA < 0) )
+    connect();
+
+  if ( mReplyQueue.size() == mNumberOfPages )
+    read();
+  write(aBuffers);
+}
+
+
+void PCIe::Flush( )
+{
+  log(Debug(), "PCIe client (URI: ", Quote(uri()), ") : Flush method called");
+  while ( !mReplyQueue.empty() )
+    read();
+
+}
+
+
+void PCIe::dispatchExceptionHandler()
+{
+  // FIXME: Adapt to PCIe implementation
+  log(Notice(), "PCIe client ", Quote(id()), " (URI: ", Quote(uri()), ") : closing device files since exception detected");
+
+  ClientInterface::returnBufferToPool ( mReplyQueue );
+  disconnect();
+
+  InnerProtocol::dispatchExceptionHandler();
+}
+
+
+uint32_t PCIe::getMaxSendSize()
+{
+  return (350 * 4);
+}
+
+
+uint32_t PCIe::getMaxReplySize()
+{
+  return (350 * 4);
+}
+
+
+void PCIe::connect()
+{
+  log ( Debug() , "PCIe client is opening device file " , Quote ( mDevicePathHostToFPGA ) , " (client-to-device)" );
+
+  mDeviceFileHostToFPGA = open(mDevicePathHostToFPGA.c_str(), O_RDWR );
+  if ( mDeviceFileHostToFPGA < 0 ) {
+    exception::PCIeInitialisationError lExc;
+    log(lExc, "Cannot open host-to-FPGA device file '" + mDevicePathHostToFPGA + "'");
+    throw lExc;
+  }
+
+
+  log ( Debug() , "PCIe client is opening device file " , Quote ( mDevicePathHostToFPGA ) , " (device-to-client)" );
+  mDeviceFileFPGAToHost = open(mDevicePathFPGAToHost.c_str(), O_RDWR | O_NONBLOCK  /* for read might need O_RDWR | O_NONBLOCK */ );
+  if ( mDeviceFileFPGAToHost < 0 ) {
+    exception::PCIeInitialisationError lExc;
+    log(lExc, "Cannot open FPGA-to-host device file '" + mDevicePathFPGAToHost + "'");
+    throw lExc;
+  }
+
+  std::vector<uint32_t> lValues;
+  dmaRead(mDeviceFileFPGAToHost, 0x0, 4, lValues);
+
+  mNumberOfPages = lValues.at(0);
+  mPageSize = lValues.at(1);
+  mIndexNextPage = lValues.at(2);
+  mPublishedReplyPageCount = lValues.at(3);
+
+  log ( Info() , "PCIe client connected to device at ", Quote(mDevicePathHostToFPGA), ", ", Quote(mDevicePathHostToFPGA), "; FPGA has ", Integer(mNumberOfPages), " pages, each of size ", Integer(mPageSize), " words, index ", Integer(mIndexNextPage), " should be filled next" );
+}
+
+
+void PCIe::disconnect()
+{
+  // FIXME: Add proper implementation
+  mDeviceFileHostToFPGA = -1;
+  mDeviceFileFPGAToHost = -1;
+}
+
+
+class PacketFmt {
+public:
+  PacketFmt(const uint8_t* const, const size_t);
+  PacketFmt(const std::vector< std::pair<const uint8_t*, size_t> >& aData);
+  ~PacketFmt();
+
+  const std::vector< std::pair<const uint8_t*, size_t> > mData;
+};
+
+PacketFmt::PacketFmt(const uint8_t* const aPtr, const size_t aNrBytes) :
+  mData(1, std::pair<const uint8_t*, size_t>(aPtr, aNrBytes))
+{
+   // mData.push_back(std::pair<const uint8_t*, size_t>(aPtr, aNrBytes));
+}
+
+PacketFmt::PacketFmt(const std::vector< std::pair<const uint8_t*, size_t> >& aData) :
+  mData(aData)
+{}
+
+PacketFmt::~PacketFmt()
+{}
+
+std::ostream& operator<<(std::ostream& aStream, const PacketFmt& aPacket)
+{
+  std::ios::fmtflags lOrigFlags( aStream.flags() );
+
+  size_t lNrBytesWritten = 0;
+  for (size_t i = 0; i < aPacket.mData.size(); i++) {
+    for (const uint8_t* lPtr = aPacket.mData.at(i).first; lPtr != (aPacket.mData.at(i).first + aPacket.mData.at(i).second); lPtr++, lNrBytesWritten++) {
+      if ((lNrBytesWritten & 3) == 0)
+        aStream << std::endl << "   @ " << std::setw(3) << std::dec << (lNrBytesWritten >> 2) << " :  x";
+      aStream << std::setw(2) << std::hex << uint16_t(*lPtr) << " ";
+    }
+  }
+
+  aStream.flags( lOrigFlags );
+  return aStream;
+}
+
+
+void PCIe::write(const boost::shared_ptr<Buffers>& aBuffers)
+{
+  const uint32_t lNrWordsInPacket = aBuffers->sendCounter() / 4;
+  log (Info(), "PCIe client ", Quote(id()), " (URI: ", Quote(uri()), ") : writing ", Integer(lNrWordsInPacket), "-word packet to page ", Integer(mIndexNextPage), " in ", Quote(mDevicePathHostToFPGA));
+
+  std::vector<std::pair<const uint8_t*, size_t> > lDataToWrite;
+  lDataToWrite.push_back( std::make_pair(reinterpret_cast<const uint8_t*>(&lNrWordsInPacket), sizeof lNrWordsInPacket) );
+  lDataToWrite.push_back( std::make_pair(aBuffers->getSendBuffer(), aBuffers->sendCounter()) );
+  dmaWrite(mDeviceFileHostToFPGA, mIndexNextPage * 4 * mPageSize, lDataToWrite);
+
+  log (Debug(), "Writing " , Integer(lNrWordsInPacket), " 32-bit words at address " , Integer(mIndexNextPage * 4 * mPageSize), " ... ", PacketFmt(lDataToWrite));
+
+  mIndexNextPage = (mIndexNextPage + 1) % mNumberOfPages;
+  mReplyQueue.push_back(aBuffers);
+}
+
+
+// -------------------------------------------------------------------------------
+
+void PCIe::read()
+{
+  const size_t lPageIndexToRead = (mIndexNextPage - mReplyQueue.size() + mNumberOfPages) % mNumberOfPages;
+  SteadyClock_t::time_point lStartTime = SteadyClock_t::now();
+
+  uint32_t lHwPublishedPageCount = 0x0;
+  while ( true ) {
+    std::vector<uint32_t> lValues;
+    // FIXME : Improve by simply adding dmaWrite method that takes uint32_t ref as argument (or returns uint32_t)
+    dmaRead(mDeviceFileFPGAToHost, 3, 1, lValues);
+    lHwPublishedPageCount = lValues.at(0);
+
+    if (lHwPublishedPageCount != mPublishedReplyPageCount) {
+      mPublishedReplyPageCount++;
+      break;
+    }
+    // FIXME: Throw if published page count is invalid number
+
+    if (SteadyClock_t::now() - lStartTime > boost::chrono::microseconds(getBoostTimeoutPeriod().total_microseconds())) {
+      exception::PCIeTimeout lExc;
+      log(lExc, "Next page (index ", Integer(lPageIndexToRead), " count ", Integer(mPublishedReplyPageCount+1), ") of PCIe device '" + mDevicePathHostToFPGA + "' is not ready after timeout period");
+      throw lExc;
+    }
+
+    log(Debug(), "PCIe client ", Quote(id()), " (URI: ", Quote(uri()), ") : Trying to read page index ", Integer(lPageIndexToRead), " = count ", Integer(mPublishedReplyPageCount+1), "; published page count is ", Integer(lHwPublishedPageCount), "; sleeping for a while ...");
+    boost::this_thread::sleep_for( boost::chrono::microseconds(50));
+  }
+
+  log(Info(), "PCIe client ", Quote(id()), " (URI: ", Quote(uri()), ") : Reading page ", Integer(lPageIndexToRead), " (published count ", Integer(lHwPublishedPageCount), ", surpasses required, ", Integer(mPublishedReplyPageCount), ")");
+
+  // PART 1 : Read the page
+  boost::shared_ptr<Buffers> lBuffers = mReplyQueue.front();
+  mReplyQueue.pop_front();
+
+  std::vector<uint32_t> lPageContents;
+  dmaRead(mDeviceFileFPGAToHost, 4 + lPageIndexToRead * 4 * mPageSize, 1 + (lBuffers->replyCounter() >> 2), lPageContents);
+  log (Debug(), "Read " , Integer(1 + (lBuffers->replyCounter() >> 2)), " 32-bit words from address " , Integer(4 + lPageIndexToRead * 4 * mPageSize), " ... ", PacketFmt((const uint8_t*)lPageContents.data(), 4 * lPageContents.size()));
+
+
+  // PART 2 : Transfer to reply buffer
+  const std::deque< std::pair< uint8_t* , uint32_t > >& lReplyBuffers ( lBuffers->getReplyBuffer() );
+  size_t lNrWordsInPacket = lPageContents.at(0);
+  size_t lNrBytesCopied = 0;
+  for ( std::deque< std::pair< uint8_t* , uint32_t > >::const_iterator lIt = lReplyBuffers.begin() ; lIt != lReplyBuffers.end() ; ++lIt )
+  {
+    // Don't copy more of page than was written to, for cases when less data received than expected
+    if ( lNrBytesCopied >= 4*lNrWordsInPacket)
+      break;
+
+    size_t lNrBytesToCopy = std::min( lIt->second , uint32_t(4*lNrWordsInPacket - lNrBytesCopied) );
+    memcpy ( lIt->first, &lPageContents.at(1 + (lNrBytesCopied / 4)), lNrBytesToCopy );
+    lNrBytesCopied += lNrBytesToCopy;
+  }
+
+  // PART 3 : Validate the packet contents
+  try
+  {
+    if ( uhal::exception::exception* lExc = ClientInterface::validate ( lBuffers ) ) //Control of the pointer has been passed back to the client interface
+    {
+      mAsynchronousException = lExc;
+    }
+  }
+  catch ( exception::exception& aExc )
+  {
+    mAsynchronousException = new exception::ValidationError ();
+    log ( *mAsynchronousException , "Exception caught during reply validation for PCIe device with URI " , Quote ( this->uri() ) , "; what returned: " , Quote ( aExc.what() ) );
+  }
+}
+
+
+void PCIe::dmaRead(int aFileDescriptor, const uint32_t aAddr, const uint32_t aNrWords, std::vector<uint32_t>& aValues)
+{
+  char *allocated = NULL;
+  posix_memalign((void **)&allocated, 4096/*alignment*/, 4*aNrWords + 4096);
+  assert(allocated);
+
+  /* select AXI MM address */
+  char* buffer = allocated;
+  off_t off = lseek(aFileDescriptor, 4*aAddr, SEEK_SET);
+
+  /* read data from AXI MM into buffer using SGDMA */
+  int rc = ::read(aFileDescriptor, buffer, 4*aNrWords);
+  assert(rc >= 0);
+  assert((rc % 4) == 0);
+  if ((rc > 0) && (rc < 4*aNrWords)) {
+    std::cout << "Short read of " << rc << " bytes into a " << 4*aNrWords << " bytes buffer, could be a packet read?\n";
+  }
+
+  aValues.insert(aValues.end(), reinterpret_cast<uint32_t*>(buffer), reinterpret_cast<uint32_t*>(buffer)+ aNrWords);
+//    for (unsigned i=0; i<aNrWords; i++) {
+//      //uint32_t val = (buffer[4*i]&0xff)+((buffer[4*i+1]&0xff)<<8)+((buffer[4*i+2]&0xff)<<16)
+//      //  +((buffer[4*i+3]&0xff)<<24);
+//      uint32_t val = *reinterpret_cast<uint32_t*>(buffer);
+//      printf("ipbus address : 0x%08x\n", aAddr);
+//      printf("readback value: 0x%08x\n\n",val);
+//    }
+
+  free(allocated);
+}
+
+
+bool PCIe::dmaWrite(int aFileDescriptor, const uint32_t aAddr, const std::vector<uint32_t>& aValues)
+{
+  return dmaWrite(aFileDescriptor, 4 * aAddr, reinterpret_cast<const uint8_t* const>(aValues.data()), 4 * aValues.size());
+}
+
+
+bool PCIe::dmaWrite(int aFileDescriptor, const uint32_t aAddr, const uint8_t* const aPtr, const size_t aNrBytes)
+{
+  assert((aNrBytes % 4) == 0);
+
+  char *allocated = NULL;
+  posix_memalign((void **)&allocated, 4096/*alignment*/, aNrBytes + 4096);
+  assert(allocated);
+
+  // data to write to register address
+  char* buffer = allocated;
+  memcpy(buffer, aPtr, aNrBytes);
+
+  /* select AXI MM address */
+  off_t off = lseek(aFileDescriptor, aAddr, SEEK_SET);
+
+  /* write buffer to AXI MM address using SGDMA */
+  int rc = ::write(aFileDescriptor, buffer, aNrBytes);
+  assert(rc == aNrBytes);
+
+  free(allocated);
+
+  return true;
+}
+
+
+bool PCIe::dmaWrite(int aFileDescriptor, const uint32_t aAddr, const std::vector<std::pair<const uint8_t*, size_t> >& aData)
+{
+  size_t lNrBytes = 0;
+  for (size_t i = 0; i < aData.size(); i++)
+    lNrBytes += aData.at(i).second;
+
+  assert((lNrBytes % 4) == 0);
+
+  char *allocated = NULL;
+  posix_memalign((void **)&allocated, 4096/*alignment*/, lNrBytes + 4096);
+  assert(allocated);
+
+  // data to write to register address
+  char* buffer = allocated;
+  size_t lNrBytesCopied = 0;
+  for (size_t i = 0; i < aData.size(); i++) {
+    memcpy(buffer + lNrBytesCopied, aData.at(i).first, aData.at(i).second);
+    lNrBytesCopied += aData.at(i).second;
+  }
+
+  /* select AXI MM address */
+  off_t off = lseek(aFileDescriptor, aAddr, SEEK_SET);
+
+  /* write buffer to AXI MM address using SGDMA */
+  int rc = ::write(aFileDescriptor, buffer, lNrBytes);
+  assert(rc == lNrBytes);
+
+  free(allocated);
+
+  return true;
+}
+
+
+} // end ns uhal


### PR DESCRIPTION
This pull request implements a single-thread client for communicating with IPbus 2.0 firmware over PCIe, using the CPU-FPGA interface given in the opening description of issue #83 

Additionally, this pull request implements a PCIe version of the dummy hardware, and updates the repository's CI config to automatically test the PCIe client (as is already done for direct UDP, UDP via ControlHub, and TCP clients).