### PR TITLE
Add tests for readConfigurationSpace method

### DIFF
--- a/uhal/pycohal/src/common/cactus_pycohal.cpp
+++ b/uhal/pycohal/src/common/cactus_pycohal.cpp
@@ -248,7 +248,7 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS ( uhal_ClientInterface_write_overloads,  
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS ( uhal_ClientInterface_writeBlock_overloads, writeBlock, 2, 3 )
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS ( uhal_ClientInterface_read_overloads,       read,       1, 2 )
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS ( uhal_ClientInterface_readBlock_overloads,  readBlock,  2, 3 )
-BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS ( uhal_IPbusCore_read_overloads,             read,       1, 2 )
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS ( uhal_IPbusCore_readConfigurationSpace_overloads, readConfigurationSpace, 1, 2 )
 
 
 // *** N.B: The argument of this BOOST_PYTHON_MODULE macro MUST be the same as the name of the library created, i.e. if creating library file my_py_binds_module.so , imported in python as:
@@ -347,7 +347,7 @@ BOOST_PYTHON_MODULE ( _core )
 
   class_<uhal::IPbusCore, bases<uhal::ClientInterface>, boost::noncopyable /* no to-python converter (would require a copy CTOR) */,
          boost::shared_ptr<uhal::IPbusCore> /* all instances are held within boost::shared_ptr */ >("IPbusCore", no_init /* no CTORs */)
-         .def ( "readConfigurationSpace", ( uhal::ValWord<uint32_t> ( uhal::IPbusCore::* ) ( const uint32_t&, const uint32_t& ) ) 0, uhal_IPbusCore_read_overloads() )
+         .def ( "readConfigurationSpace", ( uhal::ValWord<uint32_t> ( uhal::IPbusCore::* ) ( const uint32_t&, const uint32_t& ) ) 0, uhal_IPbusCore_readConfigurationSpace_overloads() )
          ;
 
   class_<uhal::UDP<uhal::IPbus<1, 3> >, bases<uhal::IPbusCore>,

--- a/uhal/pycohal/src/common/exceptions.cpp
+++ b/uhal/pycohal/src/common/exceptions.cpp
@@ -42,6 +42,7 @@ void pycohal::wrap_exceptions() {
   wrap_exception_class<uhal::exception::WriteAccessDenied> ( "WriteAccessDenied", baseExceptionPyType );
   wrap_exception_class<uhal::exception::ReadAccessDenied> ( "ReadAccessDenied",  baseExceptionPyType );
   wrap_exception_class<uhal::exception::BitsSetWhichAreForbiddenByBitMask> ( "BitsSetWhichAreForbiddenByBitMask", baseExceptionPyType );
+  wrap_exception_class<uhal::exception::ValidationError> ( "ValidationError", baseExceptionPyType );
   wrap_exception_class<uhal::exception::TcpTimeout> ( "TcpTimeout", baseExceptionPyType );
   wrap_exception_class<uhal::exception::UdpTimeout> ( "UdpTimeout", baseExceptionPyType );
   wrap_exception_class<pycohal::PycohalLogLevelEnumError> ( "PycohalLogLevelEnumError", baseExceptionPyType );

--- a/uhal/tests/include/uhal/tests/DummyHardware.hpp
+++ b/uhal/tests/include/uhal/tests/DummyHardware.hpp
@@ -135,7 +135,13 @@ namespace uhal
           @param aAddress the base address of the read
         */
         void read ( const uint32_t& aAddress );
-  
+
+        /**
+          Analyse request and create reply when an incrementing "configuration space" read is observed
+          @param aAddress the base address of the read
+        */
+        void readConfigurationSpace ( const uint32_t& aAddress );
+
         /**
           Analyse request and create reply when a non-incrementing write is observed
           @param aAddress the base address of the write
@@ -196,6 +202,9 @@ namespace uhal
       private:
         //! The memory space of the virtual hardware
         std::vector< uint32_t > mMemory;
+
+        //! The configuration space within the virtual hardware
+        std::vector< uint32_t > mConfigurationSpace;
   
       protected:
         //! The buffer for the incoming IPbus packet

--- a/uhal/tests/scripts/test_pycohal
+++ b/uhal/tests/scripts/test_pycohal
@@ -577,6 +577,40 @@ class TestRawClient(unittest.TestCase):
         self.assertEqual(total, reg.value())
 
 
+class TestConfigSpace(unittest.TestCase):
+    """
+    TestCase sub-class checking read behaviour for a single register in configuration space.
+    Analogous to C++ code in test_config_space.cpp
+    """
+
+    def test_read_fullWord(self):
+        manager = uhal.ConnectionManager( CONNECTIONS_FILE )
+        client = manager.getDevice( DEVICE_ID ).getClient()
+
+        for i in range(10):
+            if "-1.3://" in client.uri():
+                self.assertRaises(uhal.ValidationError, client.readConfigurationSpace, i)
+            else:
+                x = client.readConfigurationSpace(i)
+                client.dispatch()
+                self.assertEqual(x.value() & 0xFFFF, i)
+
+    def test_read_masked(self):
+        manager = uhal.ConnectionManager( CONNECTIONS_FILE )
+        client = manager.getDevice( DEVICE_ID ).getClient()
+
+        for i in range(10):
+            if "-1.3://" in client.uri():
+                self.assertRaises(uhal.ValidationError, client.readConfigurationSpace, i, 0xFF)
+            else:
+                x_lower = client.readConfigurationSpace(i, 0xFF)
+                x_mid = client.readConfigurationSpace(i, 0xFFFF00)
+                client.dispatch()
+                self.assertEqual(x_lower.value(), i & 0xFF)
+                self.assertEqual(x_mid.value(), (i & 0xFFFF00) >> 8)
+
+
+
 class TestCheckPermissions(unittest.TestCase):
     """
     TestCase sub-class checking that node permissions defined in xml file are enforced correctly.

--- a/uhal/tests/src/common/test_config_space.cpp
+++ b/uhal/tests/src/common/test_config_space.cpp
@@ -1,0 +1,106 @@
+/*
+---------------------------------------------------------------------------
+
+    This file is part of uHAL.
+
+    uHAL is a hardware access library and programming framework
+    originally developed for upgrades of the Level-1 trigger of the CMS
+    experiment at CERN.
+
+    uHAL is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    uHAL is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with uHAL.  If not, see <http://www.gnu.org/licenses/>.
+
+      Marc Magrans de Abril, CERN
+      email: marc.magrans.de.abril <AT> cern.ch
+
+      Andrew Rose, Imperial College, London
+      email: awr01 <AT> imperial.ac.uk
+
+      Tom Williams, Rutherford Appleton Laboratory, Oxfordshire
+      email: tom.williams <AT> cern.ch
+
+---------------------------------------------------------------------------
+*/
+
+#include "uhal/uhal.hpp"
+#include "uhal/ProtocolIPbusCore.hpp"
+
+#include "uhal/tests/definitions.hpp"
+#include "uhal/tests/fixtures.hpp"
+#include "uhal/tests/tools.hpp"
+
+#include <boost/test/unit_test.hpp>
+
+
+
+namespace uhal {
+namespace tests {
+
+
+UHAL_TESTS_DEFINE_CLIENT_TEST_CASES(ConfigSpaceTestSuite, read_fullWord, DummyHardwareFixture,
+{
+  HwInterface hw = getHwInterface();
+
+  IPbusCore& client = dynamic_cast<IPbusCore&>(hw.getClient());
+
+  for (size_t i = 0; i < 10; i++) {
+    const uint32_t expectedValue = uint16_t(getpid()) << 16 | i;
+
+    switch (deviceType) {
+      case IPBUS_1_3_UDP :
+      case IPBUS_1_3_TCP :
+      case IPBUS_1_3_CONTROLHUB :
+        BOOST_CHECK_THROW(client.readConfigurationSpace(i), exception::ValidationError);
+        break;
+      default:
+        ValWord<uint32_t> x = client.readConfigurationSpace(i);
+
+        client.dispatch();
+        BOOST_CHECK_EQUAL(x.value(), expectedValue);
+    }
+  }
+}
+)
+
+UHAL_TESTS_DEFINE_CLIENT_TEST_CASES(ConfigSpaceTestSuite, read_masked, DummyHardwareFixture,
+{
+  HwInterface hw = getHwInterface();
+
+  IPbusCore& client = dynamic_cast<IPbusCore&>(hw.getClient());
+
+  for (size_t i = 0; i < 10; i++) {
+    const uint32_t expectedValue = uint16_t(getpid()) << 16 | i;
+
+    switch (deviceType) {
+      case IPBUS_1_3_UDP :
+      case IPBUS_1_3_TCP :
+      case IPBUS_1_3_CONTROLHUB :
+        BOOST_CHECK_THROW(ValWord<uint32_t> x_lower = client.readConfigurationSpace(i, 0xFF), exception::ValidationError);
+        break;
+      default:
+        ValWord<uint32_t> x_lower = client.readConfigurationSpace(i, 0xFF);
+        ValWord<uint32_t> x_mid   = client.readConfigurationSpace(i, 0xFFFF00);
+        ValWord<uint32_t> x_upper = client.readConfigurationSpace(i, 0xFF000000);
+
+        client.dispatch();
+        BOOST_CHECK_EQUAL(x_lower.value(), uint32_t(expectedValue & 0xFF));
+        BOOST_CHECK_EQUAL(x_mid.value(), uint32_t((expectedValue & 0xFFFF00) >> 8));
+        BOOST_CHECK_EQUAL(x_upper.value(), uint32_t((expectedValue & 0xFF000000) >> 24));
+    }
+  }
+}
+)
+
+} // end ns tests
+} // end ns uhal
+

--- a/uhal/tests/src/common/test_rawclient.cpp
+++ b/uhal/tests/src/common/test_rawclient.cpp
@@ -109,9 +109,8 @@ UHAL_TESTS_DEFINE_CLIENT_TEST_CASES(RawClientTestSuite, mem_write_read, DummyHar
   BOOST_CHECK ( mem.valid() );
   BOOST_CHECK_EQUAL ( mem.size(), N );
   bool correct_block_write_read = true;
-  ValVector< uint32_t >::const_iterator i=mem.begin();
-  std::vector< uint32_t >::const_iterator j=xx.begin();
 
+  std::vector< uint32_t >::const_iterator j=xx.begin();
   for ( ValVector< uint32_t >::const_iterator i ( mem.begin() ); i!=mem.end(); ++i , ++j )
   {
     correct_block_write_read = correct_block_write_read && ( *i == *j );

--- a/uhal/uhal/include/uhal/IPbusInspector.hpp
+++ b/uhal/uhal/include/uhal/IPbusInspector.hpp
@@ -122,6 +122,12 @@ namespace uhal
       virtual void read ( const uint32_t& aAddress );
 
       /**
+        Virtual callback function called when an incrementing "configuration space" read is observed
+        @param aAddress the base address of the read
+      */
+      virtual void readConfigurationSpace ( const uint32_t& aAddress );
+
+      /**
         Virtual callback function called when a non-incrementing write is observed
         @param aAddress the base address of the write
         @param aIt iterator to the start of the payload

--- a/uhal/uhal/src/common/IPbusInspector.cpp
+++ b/uhal/uhal/src/common/IPbusInspector.cpp
@@ -136,6 +136,10 @@ namespace uhal
               lAddress = *aIt++;
               read ( lAddress );
               break;
+            case CONFIG_SPACE_READ:
+              lAddress = *aIt++;
+              readConfigurationSpace( lAddress );
+              break;
             case NI_WRITE:
               lAddress = *aIt++;
               lPayloadBegin = aIt;
@@ -205,6 +209,14 @@ namespace uhal
   void  HostToTargetInspector<IPbus_major , IPbus_minor>::read ( const uint32_t& aAddress )
   {
     log ( Notice() , Integer ( mHeader, IntFmt<hex,fixed>() ) , " | Incrementing read, size " , Integer ( mWordCounter ) , ", transaction ID " , Integer ( mTransactionId ) );
+    log ( Notice() , Integer ( aAddress, IntFmt<hex,fixed>() ) , " |  > Address" );
+  }
+
+
+  template< uint8_t IPbus_major , uint8_t IPbus_minor >
+  void  HostToTargetInspector<IPbus_major , IPbus_minor>::readConfigurationSpace ( const uint32_t& aAddress )
+  {
+    log ( Notice() , Integer ( mHeader, IntFmt<hex,fixed>() ) , " | Incrementing 'configuration space' read, size " , Integer ( mWordCounter ) , ", transaction ID " , Integer ( mTransactionId ) );
     log ( Notice() , Integer ( aAddress, IntFmt<hex,fixed>() ) , " |  > Address" );
   }
 


### PR DESCRIPTION
This pull request adds tests (both in C++ and Python) for the IPbus client `readConfigurationSpace` method - for issue #31 - and fixes a bug in the Python bindings of this method