### PR TITLE
Enable parallelisation (i.e. '-j N') in makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
 
+.NOTPARALLEL:
+
+
 Set?=all
 
 ifeq ($(Set), uhal)

--- a/uhal/.gitignore
+++ b/uhal/.gitignore
@@ -11,6 +11,7 @@ gui/dist/
 log/include/uhal/log/log.hpp
 log/include/uhal/log/log.hxx
 log/src/common/log.cpp
+log/.generated_files
 log/generator.exe
 
 pycohal/MANIFEST

--- a/uhal/Makefile
+++ b/uhal/Makefile
@@ -1,3 +1,7 @@
+
+.NOTPARALLEL:
+
+
 PACKAGES = \
 	log \
 	grammars \

--- a/uhal/log/Makefile
+++ b/uhal/log/Makefile
@@ -86,10 +86,10 @@ LibraryObjectFiles += ${PackagePath}/obj/log.o
 ${GENERATOR_EXE} : ${GENERATOR_OBJ}
 	${LD} ${LDFLAGS} $< -o $@
 
-.PHONY: _generate_log_source_code
-${GENERATED_FILES} : _generate_log_source_code
-_generate_log_source_code : ${GENERATOR_EXE}
+${GENERATED_FILES} : .generated_files
+.generated_files : ${GENERATOR_EXE}
 	./generator.exe
+	touch .generated_files
 
 .PHONY: _generator_clean
 clean: _generator_clean

--- a/uhal/log/Makefile
+++ b/uhal/log/Makefile
@@ -86,7 +86,9 @@ LibraryObjectFiles += ${PackagePath}/obj/log.o
 ${GENERATOR_EXE} : ${GENERATOR_OBJ}
 	${LD} ${LDFLAGS} $< -o $@
 
-${GENERATED_FILES} : ${GENERATOR_EXE}
+.PHONY: _generate_log_source_code
+${GENERATED_FILES} : _generate_log_source_code
+_generate_log_source_code : ${GENERATOR_EXE}
 	./generator.exe
 
 .PHONY: _generator_clean


### PR DESCRIPTION
This pull request - part of issue #47 - updates the higher-level makefiles, and the `uhal/log` Makefile, so that the source code can be built with multiple recipes running in parallel (e.g. `-j 2`).