### PR TITLE
Re-add 'uhal/Utilities.hpp' header file with deprecation message, for backward compatibility

### DIFF
--- a/uhal/uhal/include/uhal/Utilities.hpp
+++ b/uhal/uhal/include/uhal/Utilities.hpp
@@ -1,0 +1,14 @@
+
+#ifndef _uhal_Utilities_hpp_
+#define _uhal_Utilities_hpp_
+
+
+#include "uhal/utilities/bits.hpp"
+#include "uhal/utilities/files.hpp"
+#include "uhal/utilities/xml.hpp"
+
+
+#warning The header file "uhal/Utilities.hpp" has now been deprecated, and will be removed in a future uHAL release. The functions declared therein have been moved to "uhal/utilities/bits.hpp", "uhal/utilities/files.hpp" and "uhal/utilities/xml.hpp". 
+
+
+#endif


### PR DESCRIPTION
This pull request (part of issue #72 ) re-adds the `uhal/Utilities.hpp` header file - removed in earlier cleanup - with a deprecation message; the reason for this is to ensure backward compatibility for users that directly include that file. `uhal/Utilities.hpp` will be removed in some future release.