### PR TITLE
uHAL : Dynamically set page size in PCIe client

### DIFF
--- a/uhal/tests/src/common/test_block.cpp
+++ b/uhal/tests/src/common/test_block.cpp
@@ -234,7 +234,7 @@ UHAL_TESTS_DEFINE_CLIENT_TEST_CASES(BlockReadWriteTestSuite, block_offset_write_
 )
 
 
-UHAL_TESTS_DEFINE_CLIENT_TEST_CASES(BlockReadWriteTestSuite, block_access_type_violations, MinimalFixture,
+UHAL_TESTS_DEFINE_CLIENT_TEST_CASES(BlockReadWriteTestSuite, block_access_type_violations, DummyHardwareFixture,
 {
   HwInterface hw = getHwInterface();
   std::vector<uint32_t> xx;

--- a/uhal/uhal/src/common/ProtocolPCIe.cpp
+++ b/uhal/uhal/src/common/ProtocolPCIe.cpp
@@ -121,13 +121,19 @@ void PCIe::dispatchExceptionHandler()
 
 uint32_t PCIe::getMaxSendSize()
 {
-  return (350 * 4);
+  if ( (mDeviceFileFPGAToHost < 0) && (mDeviceFileHostToFPGA < 0) )
+    connect();
+
+  return (mPageSize - 1) * 4;
 }
 
 
 uint32_t PCIe::getMaxReplySize()
 {
-  return (350 * 4);
+  if ( (mDeviceFileFPGAToHost < 0) && (mDeviceFileHostToFPGA < 0) )
+    connect();
+
+  return (mPageSize - 1) * 4;
 }
 
 


### PR DESCRIPTION
This pull request (part of issue #83) updates the PCIe client to set the maximum send/reply buffer size based on status info read from firmware