### PR TITLE
uHAL : Log extra information following timeouts in ControlHub-related clients

### DIFF
--- a/controlhub/include/ch_log.hrl
+++ b/controlhub/include/ch_log.hrl
@@ -38,9 +38,9 @@
 %% ----------------------------------------------------------------------------
 -ifdef(log_debug).
 
--define( CH_LOG_DEBUG(MESSAGE), ch_utils:log(debug, ?MODULE, MESSAGE) ).
--define( CH_LOG_DEBUG(MESSAGE, MESSAGE_DATA), ch_utils:log(debug, ?MODULE, MESSAGE, MESSAGE_DATA) ).
--define( CH_LOG_DEBUG(PREFIX, MESSAGE, MESSAGE_DATA), ch_utils:log({debug, PREFIX}, ?MODULE, MESSAGE, MESSAGE_DATA) ).
+-define( CH_LOG_DEBUG(MESSAGE), ch_utils:log(debug, MESSAGE, []) ).
+-define( CH_LOG_DEBUG(MESSAGE, MESSAGE_DATA), ch_utils:log(debug, MESSAGE, MESSAGE_DATA) ).
+-define( CH_LOG_DEBUG(PREFIX, MESSAGE, MESSAGE_DATA), ch_utils:log({debug, PREFIX}, MESSAGE, MESSAGE_DATA) ).
 
 -else.
 

--- a/controlhub/sys.config
+++ b/controlhub/sys.config
@@ -5,7 +5,8 @@
   %% Override lager config so that logs written to file
   {lager, [
     {handlers, [
-      {lager_file_backend, [{file, "log/info.log"}, {level, info}]}
+      {lager_file_backend, [{file, "log/info.log"}, {level, info}]},
+      {lager_file_backend, [{file, "log/debug.log"}, {level, debug}]}
     ]}
   ]}
 ].

--- a/uhal/tests/scripts/uhal_test_suite.py
+++ b/uhal/tests/scripts/uhal_test_suite.py
@@ -163,7 +163,7 @@ def get_commands(conn_file, controlhub_scripts_dir, uhal_tools_template_vhdl):
 def cleanup_cmds():
     """Return list of cleanup commands to be used in case test script interupted - e.g. by ctrl-c"""
 
-    cmds = ["sudo controlhub_stop",
+    cmds = ["controlhub_stop",
             "sudo /sbin/tc qdisc del dev lo root"]
     return cmds
 
@@ -187,7 +187,7 @@ def get_sections():
 
 def get_controlhub_status( cmd ):
   if ("dummy.controlhub" in cmd) or ("chtcp" in cmd ):
-    StdOut, ExitCode , Time = run_command("sudo controlhub_status", False)
+    StdOut, ExitCode , Time = run_command("controlhub_status", False)
     if ExitCode:
       return "controlhub_status failed, "
     else:

--- a/uhal/uhal/include/uhal/ProtocolPCIe.hpp
+++ b/uhal/uhal/include/uhal/ProtocolPCIe.hpp
@@ -70,35 +70,28 @@ namespace uhal
   //! Transport protocol to transfer an IPbus buffer via PCIe
   class PCIe : public IPbus< 2 , 0 >
   {
-    public:
-      /**
-      	Constructor
-      	@param aId the uinique identifier that the client will be given.
-      	@param aUri a struct containing the full URI of the target.
-      */
-      PCIe ( const std::string& aId, const URI& aUri );
-
     private:
       PCIe ( const PCIe& aPCIe );
 
-      /**
-       Assignment operator
-       This reassigns the endpoint, closes the existing socket and cleans up the buffers, etc. On the next call which requires the socket, it will be reopened with the new endpoint.
-       @param aUDP a UDP-protocol object to copy
-       @return reference to the current object to allow chaining of assignments
-            */
       PCIe& operator= ( const PCIe& aPCIe );
 
     public:
+      /**
+        Constructor
+        @param aId the uinique identifier that the client will be given.
+        @param aUri a struct containing the full URI of the target.
+      */
+      PCIe ( const std::string& aId, const URI& aUri );
+
       //!	Destructor
       virtual ~PCIe();
 
-    protected:
+    private:
 
       /**
-      	Send the IPbus buffer to the target, read back the response and call the packing-protocol's validate function
-      	@param aBuffers the buffer object wrapping the send and recieve buffers that are to be transported
-      	If multithreaded, adds buffer to the dispatch queue and returns. If single-threaded, calls the dispatch-worker dispatch function directly and blocks until the response is validated.
+        Send the IPbus buffer to the target, read back the response and call the packing-protocol's validate function
+        @param aBuffers the buffer object wrapping the send and recieve buffers that are to be transported
+        If multithreaded, adds buffer to the dispatch queue and returns. If single-threaded, calls the dispatch-worker dispatch function directly and blocks until the response is validated.
       */
       void implementDispatch ( boost::shared_ptr< Buffers > aBuffers );
 
@@ -111,8 +104,6 @@ namespace uhal
       //! Function which tidies up this protocol layer in the event of an exception
       virtual void dispatchExceptionHandler();
 
-
-    private:
 
       typedef IPbus< 2 , 0 > InnerProtocol;
 

--- a/uhal/uhal/include/uhal/ProtocolTCP.hpp
+++ b/uhal/uhal/include/uhal/ProtocolTCP.hpp
@@ -114,6 +114,7 @@ namespace uhal
       */
       virtual ~TCP();
 
+    private:
       /**
       	Send the IPbus buffer to the target, read back the response and call the packing-protocol's validate function
       	@param aBuffers the buffer object wrapping the send and receive buffers that are to be transported
@@ -126,15 +127,10 @@ namespace uhal
        */
       virtual void Flush( );
 
-
-    protected:
       /**
         Function which tidies up this protocol layer in the event of an exception
        */
       virtual void dispatchExceptionHandler();
-
-
-    private:
 
       /**
         Return the maximum size to be sent based on the buffer size in the target

--- a/uhal/uhal/include/uhal/ProtocolTCP.hpp
+++ b/uhal/uhal/include/uhal/ProtocolTCP.hpp
@@ -50,6 +50,7 @@
 #include <boost/asio/io_service.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/deadline_timer.hpp>
+#include <boost/chrono.hpp>
 
 #include <boost/thread/thread.hpp>
 #include <boost/thread/mutex.hpp>
@@ -268,6 +269,11 @@ namespace uhal
       */
       uhal::exception::exception* mAsynchronousException;
 
+
+      typedef boost::chrono::steady_clock SteadyClock_t;
+
+      SteadyClock_t::time_point mLastSendQueued;
+      SteadyClock_t::time_point mLastRecvQueued;
   };
 
 

--- a/uhal/uhal/include/uhal/ProtocolUDP.hpp
+++ b/uhal/uhal/include/uhal/ProtocolUDP.hpp
@@ -210,8 +210,6 @@ namespace uhal
         A block of memory into which we write replies, before copying them to their final destination
         @note This should not be necessary and was, for a while, removed, with the buffer sequence created, instead, pointing to the final destinations
         @note Tom Williams, however believes that there is a problem with scatter-gather operations of size>64 with the UDP and so has reverted it -- see https://svnweb.cern.ch/trac/cactus/ticket/259#comment:17
-        @note Reverting the code, however, may have caused a seg-fault!
-        @todo THIS NEEDS TO BE UNDERSTOOD
       */
       std::vector<uint8_t> mReplyMemory;
 

--- a/uhal/uhal/include/uhal/ProtocolUDP.hpp
+++ b/uhal/uhal/include/uhal/ProtocolUDP.hpp
@@ -111,6 +111,7 @@ namespace uhal
       */
       virtual ~UDP();
 
+    private:
       /**
       	Send the IPbus buffer to the target, read back the response and call the packing-protocol's validate function
       	@param aBuffers the buffer object wrapping the send and recieve buffers that are to be transported
@@ -123,15 +124,10 @@ namespace uhal
        */
       virtual void Flush( );
 
-
-    protected:
       /**
               Function which tidies up this protocol layer in the event of an exception
              */
       virtual void dispatchExceptionHandler();
-
-
-    private:
 
       /**
         Return the maximum size to be sent based on the buffer size in the target

--- a/uhal/uhal/include/uhal/utilities/TimeIntervalStats.hpp
+++ b/uhal/uhal/include/uhal/utilities/TimeIntervalStats.hpp
@@ -1,0 +1,51 @@
+
+#ifndef _uhal_TimeIntervalStats_hpp_
+#define _uhal_TimeIntervalStats_hpp_
+
+
+#include <queue>
+
+#include <boost/chrono.hpp>
+
+#include "uhal/utilities/TimeIntervalStats.hpp"
+
+
+namespace uhal {
+
+class TimeIntervalStats {
+public:
+  typedef boost::chrono::steady_clock Clock_t;
+
+  TimeIntervalStats();
+  ~TimeIntervalStats();
+
+  size_t size() const;
+
+  const Clock_t::duration& min() const;
+
+  const Clock_t::duration& max() const;
+
+  Clock_t::duration mean() const;
+
+  const std::queue<Clock_t::duration>& getLatestMeasurements() const;
+
+  void add(const Clock_t::time_point& aT1, const Clock_t::time_point& aT2);
+
+  void clear();
+
+private:
+  std::queue<Clock_t::duration> mLatestMeasurements;
+
+  Clock_t::duration mMin;
+  Clock_t::duration mMax;
+  Clock_t::duration mSum;
+
+  size_t nMeasurements;
+};
+
+std::ostream& operator<<(std::ostream&, const TimeIntervalStats&);
+
+} // end ns uhal
+
+
+#endif

--- a/uhal/uhal/src/common/ProtocolControlHub.cpp
+++ b/uhal/uhal/src/common/ProtocolControlHub.cpp
@@ -264,7 +264,7 @@ namespace uhal
       {
         uhal::exception::ControlHubTargetTimeout* lExc = new uhal::exception::ControlHubTargetTimeout();
         log ( *lExc , "The ControlHub did not receive any response from the target with URI ", Quote(this->uri()) );
-        log ( *lExc , "ControlHub returned error code ", Integer ( lErrorCode ), " = ", TranslatedFmt<uint16_t>(lErrorCode, translateErrorCode));
+        log ( *lExc , "ControlHub returned error code ", Integer ( lErrorCode ), " = '", TranslatedFmt<uint16_t>(lErrorCode, translateErrorCode), "'");
         return lExc ;
       }
 

--- a/uhal/uhal/src/common/ProtocolIPbus.cpp
+++ b/uhal/uhal/src/common/ProtocolIPbus.cpp
@@ -455,7 +455,7 @@ namespace uhal
         aStream << "bus timeout on read";
         break;
       case 7:
-        aStream << "bus timeout on wite";
+        aStream << "bus timeout on write";
         break;
       case 0xf:
         aStream << "outbound request";

--- a/uhal/uhal/src/common/utilities/TimeIntervalStats.cpp
+++ b/uhal/uhal/src/common/utilities/TimeIntervalStats.cpp
@@ -1,0 +1,95 @@
+
+#include "uhal/utilities/TimeIntervalStats.hpp"
+
+
+namespace uhal {
+
+TimeIntervalStats::TimeIntervalStats() :
+  nMeasurements(0)
+{
+}
+
+TimeIntervalStats::~TimeIntervalStats()
+{
+}
+
+
+size_t TimeIntervalStats::size() const
+{
+  return nMeasurements;
+}
+
+
+const TimeIntervalStats::Clock_t::duration& TimeIntervalStats::min() const
+{
+  return mMin;
+}
+
+
+const TimeIntervalStats::Clock_t::duration& TimeIntervalStats::max() const
+{
+  return mMax;
+}
+
+
+TimeIntervalStats::Clock_t::duration TimeIntervalStats::mean() const
+{
+  return mSum / nMeasurements;
+}
+
+
+const std::queue<TimeIntervalStats::Clock_t::duration>& TimeIntervalStats::getLatestMeasurements() const
+{
+  return mLatestMeasurements;
+}
+
+
+void TimeIntervalStats::add(const Clock_t::time_point& aT1, const Clock_t::time_point& aT2)
+{
+  const Clock_t::duration lInterval = aT2 - aT1;
+
+  if ((nMeasurements == 0) or (lInterval < mMin))
+  	mMin = lInterval;
+  if ((nMeasurements == 0) or (lInterval > mMax))
+  	mMax = lInterval;
+
+  mSum += lInterval;
+  nMeasurements += 1;
+
+  mLatestMeasurements.push(lInterval);
+  if (mLatestMeasurements.size() > 5)
+  	mLatestMeasurements.pop();
+}
+
+
+void TimeIntervalStats::clear()
+{
+  for (size_t i = 0; i < nMeasurements; i++)
+    mLatestMeasurements.pop();
+  assert (mLatestMeasurements.size() == 0);
+  nMeasurements = 0;
+}
+
+
+std::ostream& operator<<(std::ostream& aStream, const TimeIntervalStats& aStats)
+{
+  if (aStats.size() == 0)
+  	aStream << "no values recorded";
+  else {
+    typedef boost::chrono::duration<float, boost::milli> MilliSec_t;
+
+  	aStream << "min / mean / max = " << MilliSec_t(aStats.min()).count() << " / " 
+            << MilliSec_t(aStats.mean()).count() << " / " << MilliSec_t(aStats.max()).count() << " ms";
+  	std::queue<TimeIntervalStats::Clock_t::duration> lLatestMeasurements = aStats.getLatestMeasurements();
+  	aStream << ", last values ";
+  	while (lLatestMeasurements.size() > 0) {
+      aStream << MilliSec_t(lLatestMeasurements.front()).count() << (lLatestMeasurements.size() > 1 ? ", " : " ms");
+      lLatestMeasurements.pop();
+  	}
+  }
+
+  return aStream;
+}
+
+
+} // end ns uhal


### PR DESCRIPTION
This pull request - part of issue #98 - updates the `TCP` client class to log extra information following timeouts, in particular:
 * Number of packets in flight, and number of bytes in request packets, and expected response packets, from TCP chunk involved in timeout
 * Mean, minimum, maximum, and N recent round-trip times
 * Same set of values for time between neighbouring send & receive calls, neighbouring pairs of sends, and neighbouring pairs of receives
