### PR TITLE
Disable IPbus 2.0 PCIe client by default until software-driver interface stops evolving

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -165,12 +165,14 @@ publish_build_job:
   image: ${IPBUS_DOCKER_REGISTRY}/ipbus-sw-test-slc6:2018-01-14
   variables:
     REPO_URL_OS_SUBDIR: slc6_x86_64
+    UHAL_ENABLE_IPBUS_PCIE: ""
 
 .job_template: &centos7_test_jobTemplate
   <<: *rpmInstall_test_jobTemplate
   image: ${IPBUS_DOCKER_REGISTRY}/ipbus-sw-test-cc7:2018-01-14
   variables:
     REPO_URL_OS_SUBDIR: centos7_x86_64
+    UHAL_ENABLE_IPBUS_PCIE: ""
     TEST_SUITE_CONTROLHUB_PATH_ARGUMENT: "-p /opt/cactus/bin"
 
 
@@ -186,12 +188,16 @@ publish_build_job:
   image: ${IPBUS_DOCKER_REGISTRY}/ipbus-sw-dev-fedora26:2018-01-14__erlang19.3_gcc7.1.1_boost1.63.0_pugixml1.8
   dependencies:
     - build:fedora26
+  variables:
+    UHAL_ENABLE_IPBUS_PCIE: ""
 
 .job_template: &ubuntu16_test_jobTemplate
   <<: *simpleInstall_test_jobTemplate
   image: ${IPBUS_DOCKER_REGISTRY}/ipbus-sw-dev-ubuntu16:2018-01-14__erlang18.3_gcc5.3.1_boost1.58.0_pugixml1.7
   dependencies:
     - build:ubuntu16
+  variables:
+    UHAL_ENABLE_IPBUS_PCIE: ""
 
 
 

--- a/uhal/config/mfRPMRules.mk
+++ b/uhal/config/mfRPMRules.mk
@@ -49,5 +49,5 @@ _spec_update:
 .PHONY: cleanrpm _cleanrpm
 cleanrpm: _cleanrpm
 _cleanrpm:
-	-rm -r rpm
+	rm -rf rpm
 

--- a/uhal/uhal/src/common/ProtocolPCIe.cpp
+++ b/uhal/uhal/src/common/ProtocolPCIe.cpp
@@ -44,6 +44,7 @@
 
 #include <algorithm>                                        // for min
 #include <assert.h>
+#include <cstdlib>
 #include <fcntl.h>
 #include <iomanip>                                          // for operator<<
 #include <iostream>                                         // for operator<<
@@ -63,6 +64,7 @@
 #include "uhal/log/log_inserters.quote.hpp"                 // for Quote
 #include "uhal/log/log.hpp"
 #include "uhal/Buffers.hpp"
+#include "uhal/ClientFactory.hpp"
 
 
 namespace uhal {
@@ -79,6 +81,13 @@ PCIe::PCIe ( const std::string& aId, const URI& aUri ) :
   mPublishedReplyPageCount(0),
   mAsynchronousException ( NULL )
 {
+  if ( getenv("UHAL_ENABLE_IPBUS_PCIE") == NULL ) {
+    exception::ProtocolDoesNotExist lExc;
+    log(lExc, "The IPbus 2.0 PCIe client is still an experimental feature, since the software-driver interface could change in the future.");
+    log(lExc, "In order to enable the IPbus 2.0 PCIe client, you need to define the environment variable 'UHAL_ENABLE_IPBUS_PCIE'");
+    throw lExc;
+  }
+
   if ( aUri.mHostname.find(",") == std::string::npos ) {
     exception::PCIeInitialisationError lExc;
     log(lExc, "No comma found in hostname of PCIe client URI '" + uri() + "'; cannot construct 2 paths for device files");

--- a/uhal/uhal/src/common/ProtocolPCIe.cpp
+++ b/uhal/uhal/src/common/ProtocolPCIe.cpp
@@ -328,6 +328,11 @@ void PCIe::read()
     mAsynchronousException = new exception::ValidationError ();
     log ( *mAsynchronousException , "Exception caught during reply validation for PCIe device with URI " , Quote ( this->uri() ) , "; what returned: " , Quote ( aExc.what() ) );
   }
+
+  if ( mAsynchronousException )
+  {
+    mAsynchronousException->ThrowAsDerivedType();
+  }
 }
 
 


### PR DESCRIPTION
This pull request (part of issue #83) updates the IPbus 2.0 PCIe client so that it's constructor throws an exception unless the environment variable `UHAL_ENABLE_IPBUS_PCIE` is defined. This will be done temporarily until we are sure that no further changes will be made to the "IPbus over PCIe" software-driver/-firmware interface.

Example error message:
```
29-01-18 00:15:11.480879 [7efeb7f01780] ERROR - The IPbus 2.0 PCIe client is still an experimental feature, since the software-driver interface could change in the future.
29-01-18 00:15:11.480965 [7efeb7f01780] ERROR - In order to enable the IPbus 2.0 PCIe client, you need to define the environment variable 'UHAL_ENABLE_IPBUS_PCIE'
```