### PR TITLE
uHAL : Minor cleanup of performance-measuring functions

### DIFF
--- a/uhal/pycohal/Makefile
+++ b/uhal/pycohal/Makefile
@@ -29,7 +29,8 @@ IncludePaths = include  \
 		${PYTHON_INCLUDE_PREFIX} \
 		${BUILD_HOME}/uhal/log/include  \
 		${BUILD_HOME}/uhal/grammars/include \
-		${BUILD_HOME}/uhal/uhal/include
+		${BUILD_HOME}/uhal/uhal/include \
+		${BUILD_HOME}/uhal/tests/include
 
 LibraryPaths = \
 		${EXTERN_BOOST_LIB_PREFIX} \
@@ -37,9 +38,11 @@ LibraryPaths = \
 		${PYTHON_LIB_PREFIX} \
 		${BUILD_HOME}/uhal/log/lib \
 		${BUILD_HOME}/uhal/grammars/lib \
-		${BUILD_HOME}/uhal/uhal/lib
+		${BUILD_HOME}/uhal/uhal/lib \
+		${BUILD_HOME}/uhal/tests/lib
 
 Libraries = \
+		cactus_uhal_tests \
 		cactus_uhal_uhal \
 		cactus_uhal_log \
 		cactus_uhal_grammars \

--- a/uhal/tests/include/uhal/tests/tools.hpp
+++ b/uhal/tests/include/uhal/tests/tools.hpp
@@ -95,9 +95,13 @@ private:
 }; /* End of class Timer */
 
 
-double measureRxPerformance(const std::vector<ClientInterface*>& aClients, uint32_t aBaseAddr, uint32_t aDepth, size_t aNrIterations, bool aDispatchEachIteration, std::ostream* aOutStream);
+double measureReadLatency(ClientInterface& aClient, uint32_t aBaseAddr, uint32_t aDepth, size_t aNrIterations, bool aDispatchEachIteration, bool aVerbose);
 
-double measureTxPerformance(const std::vector<ClientInterface*>& aClients, uint32_t aBaseAddr, uint32_t aDepth, size_t aNrIterations, bool aDispatchEachIteration, std::ostream* aOutStream);
+double measureReadLatency(const std::vector<ClientInterface*>& aClients, uint32_t aBaseAddr, uint32_t aDepth, size_t aNrIterations, bool aDispatchEachIteration, bool aVerbose);
+
+double measureWriteLatency(ClientInterface& aClient, uint32_t aBaseAddr, uint32_t aDepth, size_t aNrIterations, bool aDispatchEachIteration, bool aVerbose);
+
+double measureWriteLatency(const std::vector<ClientInterface*>& aClients, uint32_t aBaseAddr, uint32_t aDepth, size_t aNrIterations, bool aDispatchEachIteration, bool aVerbose);
 
 
 } // end ns tests

--- a/uhal/tests/src/common/PerfTester.cxx
+++ b/uhal/tests/src/common/PerfTester.cxx
@@ -310,7 +310,7 @@ void uhal::tests::PerfTester::bandwidthRxTest()
     lClients.push_back( &*iClient );
   }
 
-  double totalSeconds = measureRxPerformance(lClients, m_baseAddr, m_bandwidthTestDepth, m_iterations, m_perIterationDispatch, (m_verbose ? &std::cout : NULL));
+  double totalSeconds = measureReadLatency(lClients, m_baseAddr, m_bandwidthTestDepth, m_iterations, m_perIterationDispatch, m_verbose);
   double totalPayloadKB = m_deviceURIs.size() * m_iterations * m_bandwidthTestDepth * 4. / 1024.;
   double dataRateKB_s = totalPayloadKB/totalSeconds;
   outputStandardResults ( totalSeconds );
@@ -337,7 +337,7 @@ void uhal::tests::PerfTester::bandwidthTxTest()
     lClients.push_back( &*iClient );
   }
 
-  double totalSeconds = measureTxPerformance(lClients, m_baseAddr, m_bandwidthTestDepth, m_iterations, m_perIterationDispatch, (m_verbose ? &std::cout : NULL));
+  double totalSeconds = measureWriteLatency(lClients, m_baseAddr, m_bandwidthTestDepth, m_iterations, m_perIterationDispatch, m_verbose);
   double totalPayloadKB = m_deviceURIs.size() * m_iterations * m_bandwidthTestDepth * 4. / 1024.;
   double dataRateKB_s = totalPayloadKB/totalSeconds;
   outputStandardResults ( totalSeconds );

--- a/uhal/tests/src/common/test_soak.cpp
+++ b/uhal/tests/src/common/test_soak.cpp
@@ -56,10 +56,7 @@ namespace tests {
 
 void report_rx_performance(ClientInterface& aClient, const uint32_t aBaseAddr, const uint32_t aDepth, const size_t aNrIterations, const bool aDispatchEachIteration)
 {
-  std::vector<ClientInterface*> lClients;
-  lClients.push_back(&aClient);
-
-  double totalSeconds = measureRxPerformance(lClients, aBaseAddr, aDepth, aNrIterations, aDispatchEachIteration, NULL);
+  double totalSeconds = measureReadLatency(aClient, aBaseAddr, aDepth, aNrIterations, aDispatchEachIteration, false);
   double totalPayloadKB = aNrIterations * aDepth * 4. / 1024.;
   double dataRateKB_s = totalPayloadKB/totalSeconds;
   std::cout << " --> " << aNrIterations << " reads, each " << aDepth << " x 32-bit words, took " << totalSeconds << " seconds" << std::endl
@@ -70,10 +67,7 @@ void report_rx_performance(ClientInterface& aClient, const uint32_t aBaseAddr, c
 
 void report_tx_performance(ClientInterface& aClient, const uint32_t aBaseAddr, const uint32_t aDepth, const size_t aNrIterations, const bool aDispatchEachIteration)
 {
-  std::vector<ClientInterface*> lClients;
-  lClients.push_back(&aClient);
-
-  double totalSeconds = measureTxPerformance(lClients, aBaseAddr, aDepth, aNrIterations, aDispatchEachIteration, NULL);
+  double totalSeconds = measureWriteLatency(aClient, aBaseAddr, aDepth, aNrIterations, aDispatchEachIteration, false);
   double totalPayloadKB = aNrIterations * aDepth * 4. / 1024.;
   double dataRateKB_s = totalPayloadKB/totalSeconds;
   std::cout << " --> " << aNrIterations << " writes, each " << aDepth << " x 32-bit words, took " << totalSeconds << " seconds" << std::endl

--- a/uhal/tests/src/common/tools.cpp
+++ b/uhal/tests/src/common/tools.cpp
@@ -60,16 +60,22 @@ void DummyHardwareRunner::setReplyDelay(const boost::chrono::microseconds& aDela
 }
 
 
-double measureRxPerformance(const std::vector<ClientInterface*>& aClients, uint32_t aBaseAddr, uint32_t aDepth, size_t aNrIterations, bool aDispatchEachIteration, std::ostream* aOutStream)
+double measureReadLatency(ClientInterface& aClient, uint32_t aBaseAddr, uint32_t aDepth, size_t aNrIterations, bool aDispatchEachIteration, bool aVerbose)
+{
+  return measureReadLatency(std::vector<ClientInterface*>(1, &aClient), aBaseAddr, aDepth, aNrIterations, aDispatchEachIteration, aVerbose);
+}
+
+
+double measureReadLatency(const std::vector<ClientInterface*>& aClients, uint32_t aBaseAddr, uint32_t aDepth, size_t aNrIterations, bool aDispatchEachIteration, bool aVerbose)
 {
   typedef std::vector<ClientInterface*>::const_iterator ClientIterator_t;
   Timer myTimer;
 
   for ( unsigned i = 0; i < aNrIterations ; ++i )
   {
-    if ( aOutStream )
+    if ( aVerbose )
     {
-      (*aOutStream) << "Iteration " << i << std::endl;
+      std::cout << "Iteration " << i << std::endl;
     }
 
     for (ClientIterator_t lIt = aClients.begin(); lIt != aClients.end(); lIt++)
@@ -98,7 +104,13 @@ double measureRxPerformance(const std::vector<ClientInterface*>& aClients, uint3
 }
 
 
-double measureTxPerformance(const std::vector<ClientInterface*>& aClients, uint32_t aBaseAddr, uint32_t aDepth, size_t aNrIterations, bool aDispatchEachIteration, std::ostream* aOutStream)
+double measureWriteLatency(ClientInterface& aClient, uint32_t aBaseAddr, uint32_t aDepth, size_t aNrIterations, bool aDispatchEachIteration, bool aVerbose)
+{
+  return measureWriteLatency(std::vector<ClientInterface*>(1, &aClient), aBaseAddr, aDepth, aNrIterations, aDispatchEachIteration, aVerbose);
+}
+
+
+double measureWriteLatency(const std::vector<ClientInterface*>& aClients, uint32_t aBaseAddr, uint32_t aDepth, size_t aNrIterations, bool aDispatchEachIteration, bool aVerbose)
 {
   typedef std::vector<ClientInterface*>::const_iterator ClientIterator_t;
 
@@ -108,9 +120,9 @@ double measureTxPerformance(const std::vector<ClientInterface*>& aClients, uint3
 
   for ( unsigned i = 0; i < aNrIterations ; ++i )
   {
-    if ( aOutStream )
+    if ( aVerbose )
     {
-      (*aOutStream) << "Iteration " << i << std::endl;
+      std::cout << "Iteration " << i << std::endl;
     }
 
     // Create the packet


### PR DESCRIPTION
This pull request - part of issue #99 - is a small cleanup of the performance-measuring functions defined in `uhal/tests` ...
 * Renames latency measuring functions - `measure(Rx/Tx)Performance` becomes `measure(Read/Write)Latency` 
 * Adds Python bindings for those functions (useful in performance-measuring scripts)