### PR TITLE
uHAL : Update IPbus PCIe client to support interrupts

### DIFF
--- a/uhal/grammars/src/common/URIGrammar.cpp
+++ b/uhal/grammars/src/common/URIGrammar.cpp
@@ -49,7 +49,7 @@ namespace grammars
     // PCIeURI     = protocol > empty_string > empty_string >  path      > empty_string   > - ( data_pairs_vector );
 
     protocol = + ( qi::char_ - qi::lit ( ":" ) ) > qi::lit ( "://" );
-    hostname = + ( qi::char_ - qi::lit ( ":" ) ) ;
+    hostname = + ( qi::char_ - qi::lit ( ":" ) - qi::lit ( "?" ) ) ;
     port 	 = qi::lit ( ":" ) > + ( qi::char_ - ascii::punct ) ;
     path 				= qi::lit ( "/" ) > + ( qi::char_ - qi::lit ( "." ) - qi::lit ( "?" ) );
     extension 			= qi::lit ( "." ) > + ( qi::char_ - qi::lit ( "?" ) ) ;

--- a/uhal/tests/src/common/test_uri.cpp
+++ b/uhal/tests/src/common/test_uri.cpp
@@ -1,0 +1,122 @@
+/*
+---------------------------------------------------------------------------
+
+    This file is part of uHAL.
+
+    uHAL is a hardware access library and programming framework
+    originally developed for upgrades of the Level-1 trigger of the CMS
+    experiment at CERN.
+
+    uHAL is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    uHAL is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with uHAL.  If not, see <http://www.gnu.org/licenses/>.
+
+      Tom Williams, Rutherford Appleton Laboratory, Oxfordshire
+      email: tom.williams <AT> cern.ch
+
+---------------------------------------------------------------------------
+*/
+
+#include "uhal/grammars/URI.hpp"
+#include "uhal/grammars/URIGrammar.hpp"
+
+#include <boost/test/unit_test.hpp>
+
+
+namespace uhal {
+namespace tests {
+
+URI parseURI(const std::string& aUri)
+{
+  URI lUri;
+
+  grammars::URIGrammar lGrammar;
+  std::string::const_iterator lBegin ( aUri.begin() );
+  std::string::const_iterator lEnd ( aUri.end() );
+  boost::spirit::qi::phrase_parse ( lBegin , lEnd , lGrammar , boost::spirit::ascii::space , lUri );
+
+  return lUri;
+}
+
+
+BOOST_AUTO_TEST_SUITE( grammars )
+
+BOOST_AUTO_TEST_SUITE( uri )
+
+BOOST_AUTO_TEST_CASE (udp)
+{
+  URI lURI = parseURI("ipbusudp-2.0://someHost.xyz:2468");
+
+  BOOST_CHECK_EQUAL(lURI.mProtocol, "ipbusudp-2.0");
+  BOOST_CHECK_EQUAL(lURI.mHostname, "someHost.xyz");
+  BOOST_CHECK_EQUAL(lURI.mPort, "2468");
+  BOOST_CHECK_EQUAL(lURI.mPath, "");
+  BOOST_CHECK_EQUAL(lURI.mExtension, "");
+  BOOST_CHECK(lURI.mArguments.empty());
+}
+
+BOOST_AUTO_TEST_CASE (controlhub)
+{
+  URI lURI = parseURI("chtcp-2.0://someHost.xyz:2468?target=other-host.domain:3579");
+
+  BOOST_CHECK_EQUAL(lURI.mProtocol, "chtcp-2.0");
+  BOOST_CHECK_EQUAL(lURI.mHostname, "someHost.xyz");
+  BOOST_CHECK_EQUAL(lURI.mPort, "2468");
+  BOOST_CHECK_EQUAL(lURI.mPath, "");
+  BOOST_CHECK_EQUAL(lURI.mExtension, "");
+  BOOST_CHECK_EQUAL(lURI.mArguments.size(), size_t(1));
+  BOOST_CHECK_EQUAL(lURI.mArguments.at(0).first, "target");
+  BOOST_CHECK_EQUAL(lURI.mArguments.at(0).second, "other-host.domain:3579");
+}
+
+BOOST_AUTO_TEST_CASE (pcie)
+{
+  URI lURI = parseURI("ipbuspcie-2.0:///dev/aFile,/dev/anotherFile");
+
+  BOOST_CHECK_EQUAL(lURI.mProtocol, "ipbuspcie-2.0");
+  BOOST_CHECK_EQUAL(lURI.mHostname, "/dev/aFile,/dev/anotherFile");
+  BOOST_CHECK_EQUAL(lURI.mPort, "");
+  BOOST_CHECK_EQUAL(lURI.mPath, "");
+  BOOST_CHECK_EQUAL(lURI.mExtension, "");
+  BOOST_CHECK(lURI.mArguments.empty());
+
+  lURI = parseURI("ipbuspcie-2.0:///dev/aFile,/dev/anotherFile?events=/path/to/someOtherFile");
+
+  BOOST_CHECK_EQUAL(lURI.mProtocol, "ipbuspcie-2.0");
+  BOOST_CHECK_EQUAL(lURI.mHostname, "/dev/aFile,/dev/anotherFile");
+  BOOST_CHECK_EQUAL(lURI.mPort, "");
+  BOOST_CHECK_EQUAL(lURI.mPath, "");
+  BOOST_CHECK_EQUAL(lURI.mExtension, "");
+  BOOST_CHECK_EQUAL(lURI.mArguments.size(), size_t(1));
+  BOOST_CHECK_EQUAL(lURI.mArguments.at(0).first, "events");
+  BOOST_CHECK_EQUAL(lURI.mArguments.at(0).second, "/path/to/someOtherFile");
+
+  lURI = parseURI("ipbuspcie-2.0:///dev/aFile,/dev/anotherFile?events=/path/to/someOtherFile&sleep=20");
+
+  BOOST_CHECK_EQUAL(lURI.mProtocol, "ipbuspcie-2.0");
+  BOOST_CHECK_EQUAL(lURI.mHostname, "/dev/aFile,/dev/anotherFile");
+  BOOST_CHECK_EQUAL(lURI.mPort, "");
+  BOOST_CHECK_EQUAL(lURI.mPath, "");
+  BOOST_CHECK_EQUAL(lURI.mExtension, "");
+  BOOST_CHECK_EQUAL(lURI.mArguments.at(0).first, "events");
+  BOOST_CHECK_EQUAL(lURI.mArguments.at(0).second, "/path/to/someOtherFile");
+  BOOST_CHECK_EQUAL(lURI.mArguments.at(1).first, "sleep");
+  BOOST_CHECK_EQUAL(lURI.mArguments.at(1).second, "20");
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE_END()
+
+} // end ns tests
+} // end ns uhal

--- a/uhal/uhal/include/uhal/ProtocolPCIe.hpp
+++ b/uhal/uhal/include/uhal/ProtocolPCIe.hpp
@@ -56,6 +56,14 @@
 #include "uhal/log/exception.hpp"
 #include "uhal/ProtocolIPbus.hpp"
 
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <sys/poll.h>
+#include <sys/errno.h>
 
 namespace boost
 {
@@ -162,7 +170,8 @@ namespace uhal
       int mDeviceFileHostToFPGA;
       //! File descriptor for FPGA-to-host device file
       int mDeviceFileFPGAToHost;
-
+      //! File descriptor for FPGA-to-host interrupt (event)
+      int mDeviceFileFPGAEvent;
 
       uint32_t mNumberOfPages, mPageSize, mIndexNextPage, mPublishedReplyPageCount;
 

--- a/uhal/uhal/include/uhal/ProtocolPCIe.hpp
+++ b/uhal/uhal/include/uhal/ProtocolPCIe.hpp
@@ -173,6 +173,8 @@ namespace uhal
       //! File descriptor for FPGA-to-host interrupt (event)
       int mDeviceFileFPGAEvent;
 
+      bool use_interrupt;
+
       uint32_t mNumberOfPages, mPageSize, mIndexNextPage, mPublishedReplyPageCount;
 
       //! The list of buffers still awaiting a reply

--- a/uhal/uhal/include/uhal/ProtocolPCIe.hpp
+++ b/uhal/uhal/include/uhal/ProtocolPCIe.hpp
@@ -56,14 +56,6 @@
 #include "uhal/log/exception.hpp"
 #include "uhal/ProtocolIPbus.hpp"
 
-#include <sys/mman.h>
-#include <sys/stat.h>
-#include <sys/time.h>
-#include <sys/types.h>
-#include <unistd.h>
-
-#include <sys/poll.h>
-#include <sys/errno.h>
 
 namespace boost
 {
@@ -173,7 +165,7 @@ namespace uhal
       //! File descriptor for FPGA-to-host interrupt (event)
       int mDeviceFileFPGAEvent;
 
-      bool use_interrupt;
+      bool mUseInterrupt;
 
       uint32_t mNumberOfPages, mPageSize, mIndexNextPage, mPublishedReplyPageCount;
 

--- a/uhal/uhal/include/uhal/ProtocolPCIe.hpp
+++ b/uhal/uhal/include/uhal/ProtocolPCIe.hpp
@@ -169,6 +169,8 @@ namespace uhal
 
       bool mUseInterrupt;
 
+      boost::chrono::microseconds mSleepDuration;
+
       uint32_t mNumberOfPages, mPageSize, mIndexNextPage, mPublishedReplyPageCount;
 
       //! The list of buffers still awaiting a reply

--- a/uhal/uhal/include/uhal/ProtocolPCIe.hpp
+++ b/uhal/uhal/include/uhal/ProtocolPCIe.hpp
@@ -157,6 +157,8 @@ namespace uhal
       std::string mDevicePathHostToFPGA;
       //! FPGA-to-host device file path
       std::string mDevicePathFPGAToHost;
+      //! FPGA-to-host interrupt (event) file path
+      std::string mDevicePathFPGAEvent;
 
       //! File desriptor for host-to-FPGA device file
       int mDeviceFileHostToFPGA;

--- a/uhal/uhal/src/common/ProtocolPCIe.cpp
+++ b/uhal/uhal/src/common/ProtocolPCIe.cpp
@@ -194,12 +194,12 @@ void PCIe::connect()
   
   envRet = getenv(IntEnv);
   if(envRet){
-    use_interrupt = true;
+    mUseInterrupt = true;
     log (Info() , "Using PCIe interrupt for ipbus reply packet status update");
     //std::cout << "Using interrupt" << std::endl;
   }
   else
-    use_interrupt = false;
+    mUseInterrupt = false;
 }
 
 
@@ -276,22 +276,22 @@ void PCIe::read()
   SteadyClock_t::time_point lStartTime = SteadyClock_t::now();
 
   uint32_t lHwPublishedPageCount = 0x0;
-  unsigned int rx_event[1] = {0};
-  int rc = 0;
+  unsigned int lRxEvent[1] = {0};
+  int lRC = 0;
     
   mDeviceFileFPGAEvent = open("/dev/xdma/card0/events0", O_RDONLY);
   //assert(mDeviceFileFPGAEvent >= 0);
 
   // wait for interrupt; read events file node to see if user interrupt has come
- if(use_interrupt)
+ if(mUseInterrupt)
  { 
  while (true){
-    rx_event[0] = 0;
-    rc = 0;
+    lRxEvent[0] = 0;
+    lRC = 0;
     
     //  mDeviceFileFPGAEvent = open("/dev/xdma/card0/events0", O_RDONLY);
-    rc = ::read(mDeviceFileFPGAEvent, rx_event, 4);
-    if(rx_event[0] == 1) {
+    lRC = ::read(mDeviceFileFPGAEvent, lRxEvent, 4);
+    if(lRxEvent[0] == 1) {
         //std::cout <<" \n Interrupt recieved " << std::endl;
      break;
     }

--- a/uhal/uhal/src/common/ProtocolPCIe.cpp
+++ b/uhal/uhal/src/common/ProtocolPCIe.cpp
@@ -187,7 +187,7 @@ uint32_t PCIe::getMaxReplySize()
 
 void PCIe::connect()
 {
- log ( Debug() , "PCIe client is opening device file " , Quote ( mDevicePathHostToFPGA ) , " (client-to-device)" );
+  log ( Debug() , "PCIe client is opening device file " , Quote ( mDevicePathHostToFPGA ) , " (client-to-device)" );
 
   mDeviceFileHostToFPGA = open(mDevicePathHostToFPGA.c_str(), O_RDWR );
   if ( mDeviceFileHostToFPGA < 0 ) {


### PR DESCRIPTION
This pull request updates the uHAL PCIe client to support:
 * The use of interrupts to communicate when response pages have been filled
 * Setting the period between reading status information / the interrupt 'event' file via the URI, through the `sleep` attribute

The default behaviour of the client remains polling the 'status' information, but the interrupt mechanism can be enabled by specifying the `events` attribute in the URI, e.g. `ipbuspcie-2.0:///dev/xdma0_h2c_0,/dev/xdma0_c2h_0?events=/dev/xdma0_events_0`