### PR TITLE
uHAL : Update version number for 'gui' package 

### DIFF
--- a/uhal/gui/Makefile
+++ b/uhal/gui/Makefile
@@ -9,8 +9,8 @@ PackagePath = $(CACTUS_RPM_ROOT)/${Package}
 PackageName = cactuscore-uhal-gui
 
 PACKAGE_VER_MAJOR = 2
-PACKAGE_VER_MINOR = 3
-PACKAGE_VER_PATCH = 0
+PACKAGE_VER_MINOR = 6
+PACKAGE_VER_PATCH = 1
 PACKAGE_RELEASE = 1${PACKAGE_RELEASE_SUFFIX}
 
 PackageDescription = Python GUI for uTCA HW access based on uHAL


### PR DESCRIPTION
This pull request addresses issue #113 - the uHAL gui version number should have been updated already for v2.6.0 release (in particular since ), but was accidentally not changed for that release.