### PR TITLE
IPbus over PCIe : Workaround for bugs in Xilinx 7-series PCIe XDMA core

### DIFF
--- a/uhal/uhal/include/uhal/ProtocolPCIe.hpp
+++ b/uhal/uhal/include/uhal/ProtocolPCIe.hpp
@@ -167,6 +167,8 @@ namespace uhal
       //! File descriptor for FPGA-to-host interrupt (event)
       int mDeviceFileFPGAEvent;
 
+      bool mXdma7seriesWorkaround;
+
       bool mUseInterrupt;
 
       boost::chrono::microseconds mSleepDuration;


### PR DESCRIPTION
This pull request (part of issue #83 ) updates the exact size of reads issued by the PCIe client, as a workaround for bugs in the Xilinx 7-series PCIe XDMA core. This workaround is only used if the `xdma_7series_workaround` attribute is specified in the client's URI.