### PR TITLE
Set IPBUS_SEL_WIDTH in address decoder based on number of slaves

### DIFF
--- a/uhal/tools/Makefile
+++ b/uhal/tools/Makefile
@@ -10,7 +10,7 @@ PackageName = cactuscore-uhal-tools
 
 PACKAGE_VER_MAJOR = 2
 PACKAGE_VER_MINOR = 6
-PACKAGE_VER_PATCH = 1
+PACKAGE_VER_PATCH = 2
 PACKAGE_RELEASE = 1${PACKAGE_RELEASE_SUFFIX}
 
 PackageSummary = uTCA HW Development Tools that depend on uHAL

--- a/uhal/tools/etc/uhal/tools/ipbus_addr_decode.vhd
+++ b/uhal/tools/etc/uhal/tools/ipbus_addr_decode.vhd
@@ -13,7 +13,7 @@ use ieee.numeric_std.all;
 
 package ipbus_decode_PACKAGENAME is
 
-  constant IPBUS_SEL_WIDTH: positive := 5; -- Should be enough for now?
+  constant IPBUS_SEL_WIDTH: positive := INSERT_SEL_WIDTH_HERE;
   subtype ipbus_sel_t is std_logic_vector(IPBUS_SEL_WIDTH - 1 downto 0);
   function ipbus_sel_PACKAGENAME(addr : in std_logic_vector(31 downto 0)) return ipbus_sel_t;
 

--- a/uhal/tools/scripts/gen_ipbus_addr_decode
+++ b/uhal/tools/scripts/gen_ipbus_addr_decode
@@ -256,7 +256,7 @@ def main():
 
     if not nflag:
 
-        # generate vhdl snipped with symbolic constants
+        # generate vhdl snippet with symbolic constants
         snippet1 = "-- START automatically  generated VHDL the %s \n" % time.asctime()
         slaveIds={}
         maxN=0
@@ -288,12 +288,16 @@ def main():
             
             snippet2 += "      sel := ipbus_sel_t(to_unsigned(" + slaveIds[n] + ", IPBUS_SEL_WIDTH)); -- " + str(id) + " / base " + addr_bits.hex() + " / mask " + mask.hex() + "\n"
         snippet2 += "-- END automatically generated VHDL\n"
-    
+
+        # calculate required selector bit width
+        ipbus_sel_width = math.floor(math.log(maxN+1,2))+1
+
         # print vhdl code
         vhdlfilename = "ipbus_decode_"+moduleName+".vhd"
         vhdlfile=open(vhdlfilename,"w")
         vhdlfile.write(open(template_fn).read().replace("-- INSERT_SYMBOLIC_CONSTANTS_HERE",snippet1)\
                        .replace("-- INSERT_SELECTION_HERE",snippet2)\
+                       .replace("INSERT_SEL_WIDTH_HERE","%s"%ipbus_sel_width)\
                        .replace("PACKAGENAME",moduleName))
         vhdlfile.close()
         print "VHDL decode file saved: ", vhdlfilename

--- a/uhal/tools/scripts/gen_ipbus_addr_decode
+++ b/uhal/tools/scripts/gen_ipbus_addr_decode
@@ -290,7 +290,7 @@ def main():
         snippet2 += "-- END automatically generated VHDL\n"
 
         # calculate required selector bit width
-        ipbus_sel_width = math.floor(math.log(maxN+1,2))+1
+        ipbus_sel_width = int(math.floor(math.log(maxN+1,2))+1)
 
         # print vhdl code
         vhdlfilename = "ipbus_decode_"+moduleName+".vhd"

--- a/uhal/uhal/Makefile
+++ b/uhal/uhal/Makefile
@@ -10,7 +10,7 @@ PackageName = cactuscore-uhal-uhal
 
 PACKAGE_VER_MAJOR = 2
 PACKAGE_VER_MINOR = 6
-PACKAGE_VER_PATCH = 1
+PACKAGE_VER_PATCH = 2
 PACKAGE_RELEASE = 1${PACKAGE_RELEASE_SUFFIX}
 
 PackageSummary = uHAL Library


### PR DESCRIPTION
This pull request addresses the bug outlined in issue #121 - i.e. it updates the `gen_ipbus_addr_decode` script so that it the width of `IPBUS_SEL_WIDTH` is set based on the number of slaves (rather than hardcoded)