### PR TITLE
Allow Python bindings to be installed outside of standard Python installation paths

### DIFF
--- a/uhal/Makefile
+++ b/uhal/Makefile
@@ -30,6 +30,11 @@ ${VIRTUAL_PACKAGES}:
 #     because removing installed files from one of the individual packages without removing any from other uhal packages
 #     would be much harder to implement (especially when coping with changes to filenames between different releases)
 
+ifndef prefix
+  PYTHON_DIRECTORIES = $(shell python -c "import site,sys; print ' '.join([x+'/*uhal*' for x in site.getsitepackages()])")
+else
+  PYTHON_DIRECTORIES = ${prefix}/lib/python*/*-packages/*uhal* ${exec_prefix}/lib/python*/*-packages/*uhal*
+endif
 include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/config/mfInstallVariables.mk
 
 .PHONY: uninstall
@@ -38,4 +43,4 @@ uninstall:
 	rm -rf $(libdir)/libcactus_uhal*
 	rm -rf $(includedir)/uhal
 	rm -rf $(sysconfdir)/uhal
-	rm -rf $(shell python -c "import site,sys; print ' '.join([x+'/*uhal*' for x in site.getsitepackages()])")
+	rm -rf $(PYTHON_DIRECTORIES)

--- a/uhal/config/mfInstallVariables.mk
+++ b/uhal/config/mfInstallVariables.mk
@@ -1,7 +1,7 @@
 
 # Installation directories for all types of files (following GNU naming convention)
-prefix = /opt/cactus
-exec_prefix = $(prefix)
+prefix ?= /opt/cactus
+exec_prefix ?= $(prefix)
 bindir = $(exec_prefix)/bin
 libdir = $(exec_prefix)/lib
 includedir = $(prefix)/include

--- a/uhal/config/mfPythonRPMRules.mk
+++ b/uhal/config/mfPythonRPMRules.mk
@@ -5,6 +5,13 @@ endif
 PackageScripts ?= []
 PackageDescription ?= None
 
+# By default, install Python bindings using same prefix & exec_prefix as main Python installation
+ifdef prefix
+    CUSTOM_INSTALL_PREFIX = true
+endif
+ifdef exec_prefix
+	CUSTOM_INSTALL_EXEC_PREFIX = true
+endif
 include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/mfInstallVariables.mk
 
 RPMBUILD_DIR=${PackagePath}/rpm/RPMBUILD
@@ -64,4 +71,4 @@ install: _setup_update
 	echo "include */*.so" > ${RPMBUILD_DIR}/MANIFEST.in
 	# Change into rpm/pkg to finally run the customized setup.py
 	if [ -f setup.cfg ]; then cp setup.cfg ${RPMBUILD_DIR}/ ; fi
-	cd ${RPMBUILD_DIR} && bindir=$(bindir) python ${PackageName}.py install
+	cd ${RPMBUILD_DIR} && bindir=$(bindir) python ${PackageName}.py install $(if ${CUSTOM_INSTALL_PREFIX},--prefix=${prefix},) $(if ${CUSTOM_INSTALL_PREFIX}${CUSTOM_INSTALL_EXEC_PREFIX},--exec-prefix=${exec_prefix},)


### PR DESCRIPTION
This pull request solves issue #123 - i.e. it updates the Makefiles so that if `prefix` and/or `exec_prefix` are specified in the `make install` command, then the Python bindings will be installed under `$prefix` and/or `$exec_prefix`