### PR TITLE
Reduce uHAL node memory usage

### DIFF
--- a/uhal/tests/src/common/test_nodes.cpp
+++ b/uhal/tests/src/common/test_nodes.cpp
@@ -367,7 +367,7 @@ void checkDescendants (const uhal::Node& aNode, const NodeFixture::Properties& a
   BOOST_CHECK_EQUAL(&aNode.getNode(""), &aNode);
 
   // 2) 'getNode' should throw given an invalid ID
-//FIXME - uncomment later    BOOST_CHECK_THROW(aNode.getNode("."), exception::NoBranchFoundWithGivenUID);
+  BOOST_CHECK_THROW(aNode.getNode("."), exception::NoBranchFoundWithGivenUID);
   BOOST_CHECK_THROW(aNode.getNode("some_invalid_id"), exception::NoBranchFoundWithGivenUID);
 
   // 3) 'getNodes' should return relative IDs of all descendants (order is not defined)
@@ -386,6 +386,9 @@ void checkDescendants (const uhal::Node& aNode, const NodeFixture::Properties& a
     BOOST_CHECK_NO_THROW(aNode.getNode(*lIt));
     BOOST_CHECK(typeid(aNode.getNode(*lIt)) == lType);
     BOOST_CHECK_EQUAL(&aNode.getNode(*lIt), &aNode.getNode(*lIt).getNode(""));
+
+    BOOST_CHECK_THROW(aNode.getNode("." + *lIt), exception::NoBranchFoundWithGivenUID);
+    BOOST_CHECK_THROW(aNode.getNode(*lIt + "."), exception::NoBranchFoundWithGivenUID);
 
     // 5) Templated 'getNode' method should return pointer to same object instance as non-templated method, but throw for invalid casts
     BOOST_CHECK_EQUAL(&aNode.getNode<Node>(*lIt), &aNode.getNode(*lIt));

--- a/uhal/uhal/include/uhal/Node.hpp
+++ b/uhal/uhal/include/uhal/Node.hpp
@@ -91,7 +91,7 @@ namespace uhal
       class const_iterator : public std::iterator< std::forward_iterator_tag , Node , ptrdiff_t, const Node* , const Node& >
       {
           friend class Node;
-          typedef std::deque< std::deque< Node* >::const_iterator > stack;
+          typedef std::deque< std::vector< Node* >::const_iterator > stack;
 
         public:
           const_iterator();
@@ -378,7 +378,7 @@ namespace uhal
       Node* mParent;
 
       //! The direct children of the node
-      std::deque< Node* > mChildren;
+      std::vector< Node* > mChildren;
 
       //! Helper to assist look-up of a particular child node, given a name
       boost::unordered_map< std::string , Node* > mChildrenMap;

--- a/uhal/uhal/include/uhal/Node.hpp
+++ b/uhal/uhal/include/uhal/Node.hpp
@@ -326,6 +326,9 @@ namespace uhal
 
 
     private:
+
+      std::string getRelativePath(const Node& aAncestor) const;
+
       /**
         Get the full path to the current node
       */

--- a/uhal/uhal/src/common/HwInterface.cpp
+++ b/uhal/uhal/src/common/HwInterface.cpp
@@ -70,7 +70,7 @@ namespace uhal
   {
     aNode.mHw = this;
 
-    for ( std::deque< Node* >::iterator lIt = aNode.mChildren.begin(); lIt != aNode.mChildren.end(); ++lIt )
+    for ( std::vector< Node* >::iterator lIt = aNode.mChildren.begin(); lIt != aNode.mChildren.end(); ++lIt )
     {
       claimNode ( **lIt );
     }

--- a/uhal/uhal/src/common/Node.cpp
+++ b/uhal/uhal/src/common/Node.cpp
@@ -102,12 +102,13 @@ namespace uhal
     mChildren ( ),
     mChildrenMap ( )
   {
-    for ( std::deque< Node* >::const_iterator lIt = aNode.mChildren.begin(); lIt != aNode.mChildren.end(); ++lIt )
+    mChildren.reserve(aNode.mChildren.size());
+    for ( std::vector< Node* >::const_iterator lIt = aNode.mChildren.begin(); lIt != aNode.mChildren.end(); ++lIt )
     {
       mChildren.push_back ( ( **lIt ).clone() );
     }
 
-    for ( std::deque< Node* >::iterator lIt = mChildren.begin(); lIt != mChildren.end(); ++lIt )
+    for ( std::vector< Node* >::iterator lIt = mChildren.begin(); lIt != mChildren.end(); ++lIt )
     {
       ( **lIt ).mParent = this;
       mChildrenMap.insert ( std::make_pair ( ( **lIt ).mUid , *lIt ) );
@@ -133,7 +134,7 @@ namespace uhal
     mClassName = aNode.mClassName;
     mParameters = aNode.mParameters;
 
-    for ( std::deque< Node* >::iterator lIt = mChildren.begin(); lIt != mChildren.end(); ++lIt )
+    for ( std::vector< Node* >::iterator lIt = mChildren.begin(); lIt != mChildren.end(); ++lIt )
     {
       if ( *lIt )
       {
@@ -145,12 +146,13 @@ namespace uhal
     mChildren.clear();
     mChildrenMap.clear();
 
-    for ( std::deque< Node* >::const_iterator lIt = aNode.mChildren.begin(); lIt != aNode.mChildren.end(); ++lIt )
+    mChildren.reserve(aNode.mChildren.size());
+    for ( std::vector< Node* >::const_iterator lIt = aNode.mChildren.begin(); lIt != aNode.mChildren.end(); ++lIt )
     {
       mChildren.push_back ( ( **lIt ).clone() );
     }
 
-    for ( std::deque< Node* >::iterator lIt = mChildren.begin(); lIt != mChildren.end(); ++lIt )
+    for ( std::vector< Node* >::iterator lIt = mChildren.begin(); lIt != mChildren.end(); ++lIt )
     {
       ( **lIt ).mParent = this;
       mChildrenMap.insert ( std::make_pair ( ( **lIt ).mUid , *lIt ) );
@@ -170,7 +172,7 @@ namespace uhal
 
   Node::~Node()
   {
-    for ( std::deque< Node* >::iterator lIt = mChildren.begin(); lIt != mChildren.end(); ++lIt )
+    for ( std::vector< Node* >::iterator lIt = mChildren.begin(); lIt != mChildren.end(); ++lIt )
     {
       if ( *lIt )
       {
@@ -412,7 +414,7 @@ namespace uhal
     aStr.flags(original_flags);
 
     // Recursively print children 
-    for ( std::deque< Node* >::const_iterator lIt = mChildren.begin(); lIt != mChildren.end(); ++lIt )
+    for ( std::vector< Node* >::const_iterator lIt = mChildren.begin(); lIt != mChildren.end(); ++lIt )
     {
       ( **lIt ).stream ( aStr , aIndent+2 );
     }

--- a/uhal/uhal/src/common/NodeTreeBuilder.cpp
+++ b/uhal/uhal/src/common/NodeTreeBuilder.cpp
@@ -545,11 +545,6 @@ namespace uhal
       for ( std::deque< Node* >::iterator lIt = aNode->mChildren.begin(); lIt != aNode->mChildren.end(); ++lIt )
       {
         aNode->mChildrenMap.insert ( std::make_pair ( ( **lIt ).mUid , *lIt ) );
-
-        for ( boost::unordered_map< std::string , Node* >::iterator lSubMapIt = ( **lIt ).mChildrenMap.begin() ; lSubMapIt != ( **lIt ).mChildrenMap.end() ; ++lSubMapIt )
-        {
-          aNode->mChildrenMap.insert ( std::make_pair ( ( **lIt ).mUid +'.'+ ( lSubMapIt->first ) , lSubMapIt->second ) );
-        }
       }
     }
   }
@@ -640,13 +635,12 @@ namespace uhal
   {
     std::stringstream lReport;
     lReport << std::hex << std::setfill ( '0' );
-    boost::unordered_map< std::string , Node* >::iterator lIt, lIt2;
-    Node* lNode1, *lNode2;
+    const Node* lNode1, *lNode2;
 
-    for ( lIt = aNode->mChildrenMap.begin() ; lIt != aNode->mChildrenMap.end() ; ++lIt )
+    for (Node::const_iterator lIt = ++aNode->begin() ; lIt != aNode->end() ; ++lIt )
     {
-      lNode1 = lIt->second;
-      lIt2 = lIt;
+      lNode1 = &*lIt;
+      Node::const_iterator lIt2 = lIt;
       lIt2++;
 
       if ( lNode1->mMode == defs::INCREMENTAL )
@@ -654,9 +648,9 @@ namespace uhal
         uint32_t lBottom1 ( lNode1->mAddr );
         uint32_t lTop1 ( lNode1->mAddr + ( lNode1->mSize - 1 ) );
 
-        for ( ; lIt2 != aNode->mChildrenMap.end() ; ++lIt2 )
+        for ( ; lIt2 != aNode->end() ; ++lIt2 )
         {
-          lNode2 = lIt2->second;
+          lNode2 = &*lIt2;
 
           if ( lNode2->mMode == defs::INCREMENTAL )
           {
@@ -666,9 +660,9 @@ namespace uhal
 
             if ( ( ( lTop2 >= lBottom1 ) && ( lTop2 <= lTop1 ) ) || ( ( lTop1 >= lBottom2 ) && ( lTop1 <= lTop2 ) ) )
             {
-              lReport << "Branch '" << lIt->first
+              lReport << "Branch '" << lNode1->getPath()
                       << "' has address range [0x" << std::setw ( 8 ) << lBottom1 << " - 0x" << std::setw ( 8 ) <<  lTop1
-                      << "] which overlaps with branch '" << lIt2->first
+                      << "] which overlaps with branch '" << lNode2->getPath()
                       << "' which has address range [0x"  << std::setw ( 8 )  <<  lBottom2  << " - 0x" << std::setw ( 8 ) <<  lTop2
                       << "]." << std::endl;
 #ifdef THROW_ON_ADDRESS_SPACE_OVERLAP
@@ -683,9 +677,9 @@ namespace uhal
 
             if ( ( lAddr2 >= lBottom1 ) && ( lAddr2 <= lTop1 ) )
             {
-              lReport << "Branch '" << lIt->first
+              lReport << "Branch '" << lNode1->getPath()
                       << "' has address range [0x"  << std::setw ( 8 ) << lBottom1 << " - 0x"  << std::setw ( 8 ) << lTop1
-                      << "] which overlaps with branch '" << lIt2->first
+                      << "] which overlaps with branch '" << lNode2->getPath()
                       << "' which has address 0x"  << std::setw ( 8 ) << lAddr2
                       << "." << std::endl;
 #ifdef THROW_ON_ADDRESS_SPACE_OVERLAP
@@ -699,9 +693,9 @@ namespace uhal
       {
         uint32_t lAddr1 ( lNode1->mAddr );
 
-        for ( ; lIt2 != aNode->mChildrenMap.end() ; ++lIt2 )
+        for ( ; lIt2 != aNode->end() ; ++lIt2 )
         {
-          lNode2 = lIt2->second;
+          lNode2 = &*lIt2;
 
           if ( lNode2->mMode == defs::INCREMENTAL )
           {
@@ -711,9 +705,9 @@ namespace uhal
 
             if ( ( lAddr1 >= lBottom2 ) && ( lAddr1 <= lTop2 ) )
             {
-              lReport <<  "Branch '" << lIt->first
+              lReport <<  "Branch '" << lNode1->getPath()
                       <<"' has address 0x"  << std::setw ( 8 ) << lAddr1
-                      <<" which overlaps with branch '" << lIt2->first
+                      <<" which overlaps with branch '" << lNode2->getPath()
                       <<"' which has address range [0x"   << std::setw ( 8 ) << lBottom2 << " - 0x"   << std::setw ( 8 ) << lTop2
                       << "]."<< std::endl;
 #ifdef THROW_ON_ADDRESS_SPACE_OVERLAP
@@ -735,7 +729,7 @@ namespace uhal
                 if ( lNode1->mMask == 0xFFFFFFFF )
                 {
                   // Node 1 is a full register, Node 2 is a masked region. Check if Node 2 is a child of Node 1 and, if not, then throw
-                  for ( std::deque< Node* >::iterator lIt = lNode1->mChildren.begin() ; lIt != lNode1->mChildren.end() ; ++lIt )
+                  for ( std::deque< Node* >::const_iterator lIt = lNode1->mChildren.begin() ; lIt != lNode1->mChildren.end() ; ++lIt )
                   {
                     if ( *lIt == lNode2 )
                     {
@@ -748,7 +742,7 @@ namespace uhal
                 if ( lShouldThrow && ( lNode2->mMask == 0xFFFFFFFF ) )
                 {
                   // Node 2 is a full register, Node 1 is a masked region. Check if Node 1 is a child of Node 2 and, if not, then throw
-                  for ( std::deque< Node* >::iterator lIt = lNode2->mChildren.begin() ; lIt != lNode2->mChildren.end() ; ++lIt )
+                  for ( std::deque< Node* >::const_iterator lIt = lNode2->mChildren.begin() ; lIt != lNode2->mChildren.end() ; ++lIt )
                   {
                     if ( *lIt == lNode1 )
                     {
@@ -760,10 +754,10 @@ namespace uhal
 
                 if ( lShouldThrow )
                 {
-                  lReport <<  "Branch '" << lIt->first
+                  lReport <<  "Branch '" << lNode1->getPath()
                           << "' has address 0x" << std::setw ( 8 ) << lAddr1
                           << " and mask 0x" << std::setw ( 8 ) << lNode1->mMask
-                          << " which overlaps with branch '" << lIt2->first
+                          << " which overlaps with branch '" << lNode2->getPath()
                           << "' which has address 0x" << std::setw ( 8 ) << lAddr2
                           << " and mask 0x" << std::setw ( 8 ) << lNode2->mMask
                           << "." << std::endl;

--- a/uhal/uhal/src/common/NodeTreeBuilder.cpp
+++ b/uhal/uhal/src/common/NodeTreeBuilder.cpp
@@ -542,7 +542,7 @@ namespace uhal
         aNode->mChildren.push_back ( mNodeParser ( lXmlNode ) );
       }
 
-      for ( std::deque< Node* >::iterator lIt = aNode->mChildren.begin(); lIt != aNode->mChildren.end(); ++lIt )
+      for ( std::vector< Node* >::iterator lIt = aNode->mChildren.begin(); lIt != aNode->mChildren.end(); ++lIt )
       {
         aNode->mChildrenMap.insert ( std::make_pair ( ( **lIt ).mUid , *lIt ) );
       }
@@ -562,7 +562,7 @@ namespace uhal
         // bool lAnyMasked( false );
         bool lAllMasked ( true );
 
-        for ( std::deque< Node* >::iterator lIt = aNode->mChildren.begin(); lIt != aNode->mChildren.end(); ++lIt )
+        for ( std::vector< Node* >::iterator lIt = aNode->mChildren.begin(); lIt != aNode->mChildren.end(); ++lIt )
         {
           if ( ( **lIt ).mMask == defs::NOMASK )
           {
@@ -620,7 +620,7 @@ namespace uhal
 
     aNode->mAddr = aNode->mPartialAddr + aAddr;
 
-    for ( std::deque< Node* >::iterator lIt = aNode->mChildren.begin(); lIt != aNode->mChildren.end(); ++lIt )
+    for ( std::vector< Node* >::iterator lIt = aNode->mChildren.begin(); lIt != aNode->mChildren.end(); ++lIt )
     {
       ( **lIt ).mParent = aNode;
       calculateHierarchicalAddresses ( *lIt , aNode->mAddr );
@@ -729,7 +729,7 @@ namespace uhal
                 if ( lNode1->mMask == 0xFFFFFFFF )
                 {
                   // Node 1 is a full register, Node 2 is a masked region. Check if Node 2 is a child of Node 1 and, if not, then throw
-                  for ( std::deque< Node* >::const_iterator lIt = lNode1->mChildren.begin() ; lIt != lNode1->mChildren.end() ; ++lIt )
+                  for ( std::vector< Node* >::const_iterator lIt = lNode1->mChildren.begin() ; lIt != lNode1->mChildren.end() ; ++lIt )
                   {
                     if ( *lIt == lNode2 )
                     {
@@ -742,7 +742,7 @@ namespace uhal
                 if ( lShouldThrow && ( lNode2->mMask == 0xFFFFFFFF ) )
                 {
                   // Node 2 is a full register, Node 1 is a masked region. Check if Node 1 is a child of Node 2 and, if not, then throw
-                  for ( std::deque< Node* >::const_iterator lIt = lNode2->mChildren.begin() ; lIt != lNode2->mChildren.end() ; ++lIt )
+                  for ( std::vector< Node* >::const_iterator lIt = lNode2->mChildren.begin() ; lIt != lNode2->mChildren.end() ; ++lIt )
                   {
                     if ( *lIt == lNode1 )
                     {


### PR DESCRIPTION
This pull request reduces the memory usage of uHAL node trees, by changing the `uhal::Node` member data as follows

 * `mChildrenMap` now only contains a map of the direct children (rather than all descendants)
 * `mChildren` is now a `vector` rather than a `std::deque`

Measuring in a dummy executable (without any clients) using `mallinfo`, for the dummy address table and the MP7 XE v2.4.0 address table, this PR reduces the node tree's memory usage by a factor of 3 to 4.