### PR TITLE
PCIe client improvements

### DIFF
--- a/uhal/tests/include/uhal/tests/PCIeDummyHardware.hpp
+++ b/uhal/tests/include/uhal/tests/PCIeDummyHardware.hpp
@@ -33,7 +33,7 @@
 */
 
 #ifndef _uhal_tests_PCIeDummyHardware_hpp_
-#define  _uhal_tests_PCIeDummyHardware_hpp_
+#define _uhal_tests_PCIeDummyHardware_hpp_
 
 
 #include "uhal/tests/DummyHardware.hpp"
@@ -56,14 +56,12 @@ public:
   void stop();
 
 private:
-  static void dmaRead(int aFileDescriptor, const uint32_t aAddr, const uint32_t aNrWords, std::vector<uint32_t>& aValues);
-
-  static void dmaBlockingRead(int aFileDescriptor, const uint32_t aAddr, const uint32_t aNrWords, std::vector<uint32_t>& aValues);
+  static void fifoRead(int aFileDescriptor, const uint32_t aAddr, const uint32_t aNrWords, std::vector<uint32_t>& aValues);
 
 
-  static bool dmaWrite(int aFileDescriptor, const uint32_t aAddr, const std::vector<uint32_t>& aValues);
+  static bool fileWrite(int aFileDescriptor, const uint32_t aAddr, const std::vector<uint32_t>& aValues);
 
-  static bool dmaWrite(int aFileDescriptor, const uint32_t aAddr, const uint8_t* const aPtr, const size_t aNrBytes);
+  static bool fileWrite(int aFileDescriptor, const uint32_t aAddr, const uint8_t* const aPtr, const size_t aNrBytes);
 
 
   std::string mDevicePathHostToFPGA, mDevicePathFPGAToHost;

--- a/uhal/tests/src/common/PCIeDummyHardware.cpp
+++ b/uhal/tests/src/common/PCIeDummyHardware.cpp
@@ -38,9 +38,12 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>
-#include <sys/types.h>
+#include <sys/ioctl.h>
 #include <sys/stat.h>
+#include <sys/types.h>
 
+#include <boost/chrono/duration.hpp>
+#include <boost/thread/thread.hpp>
 #include <boost/lexical_cast.hpp>
 
 #include "uhal/log/LogLevels.hpp"
@@ -57,7 +60,7 @@ PCIeDummyHardware::PCIeDummyHardware(const std::string& aDevicePathHostToFPGA, c
   DummyHardware<2, 0>(aReplyDelay, aBigEndianHack),
   mDevicePathHostToFPGA(aDevicePathHostToFPGA),
   mDevicePathFPGAToHost(aDevicePathFPGAToHost),
-  mNumberOfPages(1),
+  mNumberOfPages(3),
   mWordsPerPage(360),
   mNextPageIndex(0),
   mPublishedPageCount(0),
@@ -92,10 +95,10 @@ PCIeDummyHardware::PCIeDummyHardware(const std::string& aDevicePathHostToFPGA, c
   std::vector<uint32_t> lFPGAToHostData(4 + mNumberOfPages * mWordsPerPage, 0);
   lFPGAToHostData.at(0) = mNumberOfPages;
   lFPGAToHostData.at(1) = mWordsPerPage;
-  lFPGAToHostData.at(2) = mNumberOfPages;
-  lFPGAToHostData.at(2) = mNumberOfPages;
+  lFPGAToHostData.at(2) = mNextPageIndex;
+  lFPGAToHostData.at(3) = mPublishedPageCount;
 
-  dmaWrite(mDeviceFileFPGAToHost, 0, lFPGAToHostData);
+  fileWrite(mDeviceFileFPGAToHost, 0, lFPGAToHostData);
 
   log(Notice(), "Starting IPbus 2.0 PCIe dummy hardware ", Quote(mDevicePathHostToFPGA), ", ", Quote(mDevicePathFPGAToHost), "; ", Integer(mNumberOfPages), " pages, ", Integer(mWordsPerPage), " words per page");
 }
@@ -122,23 +125,20 @@ void PCIeDummyHardware::run()
   log(Info(), "Entering run method for IPbus 2.0 PCIe dummy hardware ", Quote(mDevicePathHostToFPGA), ", ", Quote(mDevicePathFPGAToHost));
 
   while ( !mStop ) {
-    fd_set lInputFileSet;
-    FD_ZERO(&lInputFileSet);
-    FD_SET(mDeviceFileHostToFPGA, &lInputFileSet);
+    int lNrBytes;
+    int lRC = ioctl(mDeviceFileHostToFPGA, FIONREAD, &lNrBytes);
+    log (Debug(), "PCIeDummyHardware::run  -  ioctl returns ", Integer(lRC), ", ", lNrBytes, " bytes available");
+    assert (lRC == 0);
 
-    timeval lTimeout;
-    lTimeout.tv_sec = 0;
-    lTimeout.tv_usec = 50000;
-    int rc = select(FD_SETSIZE, &lInputFileSet, NULL, NULL, &lTimeout);
-    log (Debug(), "PCIeDummyHardware::run  -  select returns ", Integer(rc), " Input file set ", (FD_ISSET(mDeviceFileHostToFPGA, &lInputFileSet) ? "contains" : "does not contain"),  " pty");
-
-    if (rc == 0)
+    if (lNrBytes == 0) {
+      boost::this_thread::sleep_for(boost::chrono::microseconds(50));
       continue;
+    }
 
     log(Debug(), "IPbus 2.0 PCIe dummy hardware ", Quote(mDevicePathHostToFPGA), ", ", Quote(mDevicePathFPGAToHost), " : data ready; reading 'packet length' header");
     // FIXME: Define template method that reads sizeof(T) bytes and returns T
     std::vector<uint32_t> lPageHeader;
-    dmaBlockingRead(mDeviceFileHostToFPGA, 0x0, 1, lPageHeader);
+    fifoRead(mDeviceFileHostToFPGA, 0x0, 1, lPageHeader);
 
     const uint32_t lNrWordsInRequestPacket = (lPageHeader.at(0) >> 16) + (lPageHeader.at(0) & 0xFFFF);
 
@@ -147,9 +147,9 @@ void PCIeDummyHardware::run()
       return;
     }
 
-    log(Info(), "IPbus 2.0 PCIe dummy hardware ", Quote(mDevicePathHostToFPGA), ", ", Quote(mDevicePathFPGAToHost), " : reading ", Integer(lPageHeader.at(0)), "-word packet");
+    log(Info(), "IPbus 2.0 PCIe dummy hardware ", Quote(mDevicePathHostToFPGA), ", ", Quote(mDevicePathFPGAToHost), " : reading ", Integer(lNrWordsInRequestPacket), "-word packet");
     mReceive.clear();
-    dmaBlockingRead(mDeviceFileHostToFPGA, 0x0, lNrWordsInRequestPacket, mReceive);
+    fifoRead(mDeviceFileHostToFPGA, 0x0, lNrWordsInRequestPacket, mReceive);
 
     // std::cout << "Received:" << std::endl;
     // for(size_t i=0; i<mReceive.size(); i++)
@@ -162,15 +162,22 @@ void PCIeDummyHardware::run()
     lPageHeader.clear();
     lPageHeader.push_back(0x10000 | ((mReply.size() - 1) & 0xFFFF));
 
-    dmaWrite(mDeviceFileFPGAToHost, 4 + mNextPageIndex * mWordsPerPage, lPageHeader); // FIXME: Define template dmaWrite method that takes const T& as final argument, so that don't have to define vector
-    dmaWrite(mDeviceFileFPGAToHost, 4 + mNextPageIndex * mWordsPerPage + 1, mReply);
+    fileWrite(mDeviceFileFPGAToHost, 4 + mNextPageIndex * mWordsPerPage, lPageHeader); // FIXME: Define template fileWrite method that takes const T& as final argument, so that don't have to define vector
+    fileWrite(mDeviceFileFPGAToHost, 4 + mNextPageIndex * mWordsPerPage + 1, mReply);
 
     std::vector<uint32_t> lData;
-    lData.push_back(mPublishedPageCount+1); // FIXME: Define template dmaWrite method that takes const T& as final argument, so that don't have to define vector
-    dmaWrite(mDeviceFileFPGAToHost, 3, lData);
+    lData.push_back(mPublishedPageCount+1); // FIXME: Define template fileWrite method that takes const T& as final argument, so that don't have to define vector
+    fileWrite(mDeviceFileFPGAToHost, 3, lData);
 
     mNextPageIndex = (mNextPageIndex + 1) % mNumberOfPages;
     mPublishedPageCount++;
+
+    std::vector<uint32_t> lStatusBlock(4, 0);
+    lStatusBlock.at(0) = mNumberOfPages;
+    lStatusBlock.at(1) = mWordsPerPage;
+    lStatusBlock.at(2) = mNextPageIndex;
+    lStatusBlock.at(3) = mPublishedPageCount;
+    fileWrite(mDeviceFileFPGAToHost, 0, lStatusBlock);
   }
 
   log(Info(), "Exiting run method for IPbus 2.0 PCIe dummy hardware ", Quote(mDevicePathHostToFPGA), ", ", Quote(mDevicePathFPGAToHost));
@@ -184,7 +191,7 @@ void PCIeDummyHardware::stop()
 }
 
 
-void PCIeDummyHardware::dmaRead(int aFileDescriptor, const uint32_t aAddr, const uint32_t aNrWords, std::vector<uint32_t>& aValues)
+void PCIeDummyHardware::fifoRead(int aFileDescriptor, const uint32_t aAddr, const uint32_t aNrWords, std::vector<uint32_t>& aValues)
 {
   char *allocated = NULL;
   posix_memalign((void **)&allocated, 4096/*alignment*/, 4*aNrWords + 4096);
@@ -192,69 +199,21 @@ void PCIeDummyHardware::dmaRead(int aFileDescriptor, const uint32_t aAddr, const
 
   /* select AXI MM address */
   char* buffer = allocated;
-  off_t off = lseek(aFileDescriptor, 4*aAddr, SEEK_SET);
-  if ( off != 4*aAddr) {
-    exception::PCIeCommunicationError lExc;
-    log(lExc, "Offset returned by lseek, ", Integer(off), ", does not match that requested, ", Integer(4*aAddr), " (in preparation for read of ", Integer(aNrWords), " words)");
-    throw lExc;
-  }
-
-  /* read data from AXI MM into buffer using SGDMA */
-  int rc = ::read(aFileDescriptor, buffer, 4*aNrWords);
-  assert(rc >= 0);
-  if ((rc % 4) != 0)
-    log(Fatal(), "PCIeDummyHardware::dmaRead  -  rc = ", Integer(rc));
-  assert((rc % 4) == 0);
-  if ((rc > 0) && (size_t(rc) < 4*aNrWords)) {
-    std::cout << "Short read of " << rc << " bytes into a " << 4*aNrWords << " bytes buffer, could be a packet read?\n";
-  }
-
-  aValues.insert(aValues.end(), reinterpret_cast<uint32_t*>(buffer), reinterpret_cast<uint32_t*>(buffer)+ aNrWords);
-//    for (unsigned i=0; i<aNrWords; i++) {
-//      //uint32_t val = (buffer[4*i]&0xff)+((buffer[4*i+1]&0xff)<<8)+((buffer[4*i+2]&0xff)<<16)
-//      //  +((buffer[4*i+3]&0xff)<<24);
-//      uint32_t val = *reinterpret_cast<uint32_t*>(buffer);
-//      printf("ipbus address : 0x%08x\n", aAddr);
-//      printf("readback value: 0x%08x\n\n",val);
-//    }
-
-  free(allocated);
-}
-
-
-void PCIeDummyHardware::dmaBlockingRead(int aFileDescriptor, const uint32_t aAddr, const uint32_t aNrWords, std::vector<uint32_t>& aValues)
-{
-  char *allocated = NULL;
-  posix_memalign((void **)&allocated, 4096/*alignment*/, 4*aNrWords + 4096);
-  assert(allocated);
-
-  /* select AXI MM address */
-  char* buffer = allocated;
-  off_t off = lseek(aFileDescriptor, 4*aAddr, SEEK_SET);
-  if ( off != 4*aAddr) {
-    struct stat st;
-    if (fstat(aFileDescriptor, &st) or (not S_ISFIFO(st.st_mode))) {
-      exception::PCIeCommunicationError lExc;
-      log(lExc, "Offset returned by lseek, ", Integer(off), ", does not match that requested, ", Integer(4*aAddr), " (in preparation for blocking read of ", Integer(aNrWords), " words)");
-      throw lExc;
-    }
-  }
-
   memset(buffer, 0, 4 * aNrWords);
 
   /* read data from AXI MM into buffer using SGDMA */
   size_t lNrBytesRead = 0;
   do {
     if (lNrBytesRead != 0)
-      log (Fatal(), "dmaBlockingRead calling ::read multiple times to get all expected ", Integer(aNrWords * 4), " bytes (only ", Integer(lNrBytesRead), " so far)");
+      log (Fatal(), "fifo calling ::read multiple times to get all expected ", Integer(aNrWords * 4), " bytes (only ", Integer(lNrBytesRead), " so far)");
     int rc = ::read(aFileDescriptor, buffer + lNrBytesRead, 4*aNrWords - lNrBytesRead);
     if (rc <= 0)
-      log (Fatal(), "dmaBlockingRead   -   read returned ", Integer(rc), ", bugger! errno = ", Integer(errno));
+      log (Fatal(), "fifo   -   read returned ", Integer(rc), ", bugger! errno = ", Integer(errno), ", meaning ", Quote (strerror(errno)));
     assert (rc > 0);
     lNrBytesRead += rc;
   } while (lNrBytesRead < (4 * aNrWords) );
   if (lNrBytesRead > (4 * aNrWords))
-    log (Fatal(), "dmaBlockingRead   -   read ", Integer(lNrBytesRead), " but only wanted to read  ", Integer(aNrWords * 4), " bytes");
+    log (Fatal(), "fifo   -   read ", Integer(lNrBytesRead), " but only wanted to read  ", Integer(aNrWords * 4), " bytes");
   // int rc = ::read(aFileDescriptor, buffer, 4*aNrWords);
   // assert(rc >= 0);
   // if ((rc % 4) != 0)
@@ -278,13 +237,13 @@ void PCIeDummyHardware::dmaBlockingRead(int aFileDescriptor, const uint32_t aAdd
 
 
 
-bool PCIeDummyHardware::dmaWrite(int aFileDescriptor, const uint32_t aAddr, const std::vector<uint32_t>& aValues)
+bool PCIeDummyHardware::fileWrite(int aFileDescriptor, const uint32_t aAddr, const std::vector<uint32_t>& aValues)
 {
-  return dmaWrite(aFileDescriptor, aAddr, reinterpret_cast<const uint8_t*>(aValues.data()), 4 * aValues.size());
+  return fileWrite(aFileDescriptor, aAddr, reinterpret_cast<const uint8_t*>(aValues.data()), 4 * aValues.size());
 }
 
 
-bool PCIeDummyHardware::dmaWrite(int aFileDescriptor, const uint32_t aAddr, const uint8_t* const aPtr, const size_t aNrBytes)
+bool PCIeDummyHardware::fileWrite(int aFileDescriptor, const uint32_t aAddr, const uint8_t* const aPtr, const size_t aNrBytes)
 {
   assert((aNrBytes % 4) == 0);
 

--- a/uhal/tests/src/common/PerfTester_static.cpp
+++ b/uhal/tests/src/common/PerfTester_static.cpp
@@ -214,7 +214,7 @@ bool uhal::tests::PerfTester::validation_test_write_rmwbits_read ( ClientInterfa
 
   oss_values << "Wrote value 0x" << std::hex << x0 << ", then did RMW-bits with AND-term 0x" << a << ", OR-term 0x" << b;
 
-  const bool ipbus2 = ( ( c.uri().find ( "ipbusudp-2.0" ) != string::npos ) || ( c.uri().find ( "ipbustcp-2.0" ) != string::npos ) || ( c.uri().find ( "chtcp-2.0" ) != string::npos ) || ( c.uri().find ( "ipbuspcie-2.0" ) != string::npos ) );
+  const bool ipbus2 = ( ( c.uri().find ( "ipbusudp-2.0" ) != string::npos ) || ( c.uri().find ( "ipbustcp-2.0" ) != string::npos ) || ( c.uri().find ( "chtcp-2.0" ) != string::npos ) || ( c.uri().find ( "ipbuspcie-2.0" ) != string::npos ) || ( c.uri().find ( "ipbusmmap-2.0" ) != string::npos ) );
 
   try
   {
@@ -273,7 +273,7 @@ bool uhal::tests::PerfTester::validation_test_write_rmwsum_read ( ClientInterfac
 
   oss_values << "Wrote value 0x" << std::hex << x0 << ", then did RMW-sum with ADDEND 0x" << a;
 
-  const bool ipbus2 = ( ( c.uri().find ( "ipbusudp-2.0" ) != string::npos ) || ( c.uri().find ( "ipbustcp-2.0" ) != string::npos ) || ( c.uri().find ( "chtcp-2.0" ) != string::npos )  || ( c.uri().find ( "ipbuspcie-2.0" ) != string::npos ) || ( c.uri().find ( "ipbuspcie-2.0" ) != string::npos ) );
+  const bool ipbus2 = ( ( c.uri().find ( "ipbusudp-2.0" ) != string::npos ) || ( c.uri().find ( "ipbustcp-2.0" ) != string::npos ) || ( c.uri().find ( "chtcp-2.0" ) != string::npos )  || ( c.uri().find ( "ipbuspcie-2.0" ) != string::npos ) || ( c.uri().find ( "ipbusmmap-2.0" ) != string::npos ) );
 
   try
   {

--- a/uhal/uhal/include/uhal/ProtocolMmap.hpp
+++ b/uhal/uhal/include/uhal/ProtocolMmap.hpp
@@ -1,0 +1,200 @@
+/*
+---------------------------------------------------------------------------
+
+    This file is part of uHAL.
+
+    uHAL is a hardware access library and programming framework
+    originally developed for upgrades of the Level-1 trigger of the CMS
+    experiment at CERN.
+
+    uHAL is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    uHAL is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with uHAL.  If not, see <http://www.gnu.org/licenses/>.
+
+
+      Andrew Rose, Imperial College, London
+      email: awr01 <AT> imperial.ac.uk
+
+      Marc Magrans de Abril, CERN
+      email: marc.magrans.de.abril <AT> cern.ch
+
+      Tom Williams, Rutherford Appleton Laboratory, Oxfordshire
+      email: tom.williams <AT> cern.ch
+
+---------------------------------------------------------------------------
+*/
+
+/**
+	@file
+	@author Tom Williams
+	@date September 2017
+*/
+
+#ifndef _uhal_ProtocolMmap_hpp_
+#define _uhal_ProtocolMmap_hpp_
+
+#include <deque>                           // for deque
+#include <stddef.h>                        // for size_t
+#include <stdint.h>                        // for uint32_t, uint8_t
+#include <string>                          // for string
+#include <utility>                         // for pair
+#include <vector>                          // for vector
+
+#include <boost/chrono/system_clocks.hpp>  // for steady_clock
+#include <boost/function.hpp>              // for function
+
+#include "uhal/ClientInterface.hpp"
+#include "uhal/log/exception.hpp"
+#include "uhal/ProtocolIPbus.hpp"
+
+
+namespace boost
+{
+  template <class Y> class shared_ptr;
+}
+
+namespace uhal
+{
+  class Buffers;
+  struct URI;
+
+  namespace exception
+  {
+    //! Exception class to handle the case in which the PCIe connection timed out.
+    UHAL_DEFINE_DERIVED_EXCEPTION_CLASS ( MmapTimeout , ClientTimeout , "Exception class to handle the case in which the PCIe connection timed out." )
+    //! Exception class to handle a failure to read from the specified device files during initialisation
+    UHAL_DEFINE_DERIVED_EXCEPTION_CLASS ( MmapInitialisationError , TransportLayerError , "Exception class to handle a failure to read from the specified device files during initialisation." )
+    //! Exception class to handle a low-level seek/read/write error after initialisation
+    UHAL_DEFINE_DERIVED_EXCEPTION_CLASS ( MmapCommunicationError , TransportLayerError , "Exception class to handle a low-level seek/read/write error after initialisation." )
+  }
+
+  //! Transport protocol to transfer an IPbus buffer via device file, using mmap
+  class Mmap : public IPbus< 2 , 0 >
+  {
+    public:
+      class PacketFmt {
+      public:
+        PacketFmt(const uint8_t* const, const size_t);
+        PacketFmt(const std::vector< std::pair<const uint8_t*, size_t> >& aData);
+        ~PacketFmt();
+
+        const std::vector< std::pair<const uint8_t*, size_t> > mData;
+      };
+
+    private:
+      class File {
+      public:
+        File(const std::string& aPath, int aFlags);
+        ~File();
+
+        const std::string& getPath() const;
+        void setPath(const std::string& aPath);
+
+        void open();
+        void close();
+
+        void read(const uint32_t aAddr, const uint32_t aNrWords, std::vector<uint32_t>& aValues);
+
+        void write(const uint32_t aAddr, const std::vector<std::pair<const uint8_t*, size_t> >& aData);
+
+      private:
+        std::string mPath;
+        int mFd;
+        int mFlags;
+        void* mMmapBaseAddress;
+      };
+
+      Mmap ( const Mmap& aMmap );
+
+      Mmap& operator= ( const Mmap& aMmap );
+
+    public:
+      /**
+        Constructor
+        @param aId the uinique identifier that the client will be given.
+        @param aUri a struct containing the full URI of the target.
+      */
+      Mmap ( const std::string& aId, const URI& aUri );
+
+      //!	Destructor
+      virtual ~Mmap();
+
+    private:
+
+      /**
+        Send the IPbus buffer to the target, read back the response and call the packing-protocol's validate function
+        @param aBuffers the buffer object wrapping the send and recieve buffers that are to be transported
+        If multithreaded, adds buffer to the dispatch queue and returns. If single-threaded, calls the dispatch-worker dispatch function directly and blocks until the response is validated.
+      */
+      void implementDispatch ( boost::shared_ptr< Buffers > aBuffers );
+
+      /**
+      Concrete implementation of the synchronization function to block until all buffers have been sent, all replies received and all data validated
+       */
+      virtual void Flush( );
+
+
+      //! Function which tidies up this protocol layer in the event of an exception
+      virtual void dispatchExceptionHandler();
+
+
+      typedef IPbus< 2 , 0 > InnerProtocol;
+
+      typedef boost::chrono::steady_clock SteadyClock_t;
+
+      /**
+        Return the maximum size to be sent based on the buffer size in the target
+        @return the maximum size to be sent
+      */
+      uint32_t getMaxSendSize();
+
+      /**
+        Return the maximum size of reply packet based on the buffer size in the target
+        @return the maximum size of reply packet
+      */
+      uint32_t getMaxReplySize();
+
+      //! Set up the connection to the device
+      void connect();
+
+      //! Close the connection to the device
+      void disconnect();
+
+      //! Write request packet to next page in host-to-FPGA device file 
+      void write(const boost::shared_ptr<Buffers>& aBuffers);
+
+      //! Read next pending reply packet from appropriate page of FPGA-to-host device file, and validate contents
+      void read();
+
+      bool mConnected;
+
+      File mDeviceFile;
+
+      boost::chrono::microseconds mSleepDuration;
+
+      uint32_t mNumberOfPages, mPageSize, mIndexNextPage, mPublishedReplyPageCount, mReadReplyPageCount;
+
+      //! The list of buffers still awaiting a reply
+      std::deque < boost::shared_ptr< Buffers > > mReplyQueue;
+
+      /**
+        A pointer to an exception object for passing exceptions from the worker thread to the main thread.
+        Exceptions must always be created on the heap (i.e. using `new`) and deletion will be handled in the main thread
+      */
+      uhal::exception::exception* mAsynchronousException;
+  };
+
+
+}
+
+
+#endif

--- a/uhal/uhal/include/uhal/ProtocolPCIe.hpp
+++ b/uhal/uhal/include/uhal/ProtocolPCIe.hpp
@@ -173,7 +173,7 @@ namespace uhal
 
       boost::chrono::microseconds mSleepDuration;
 
-      uint32_t mNumberOfPages, mPageSize, mIndexNextPage, mPublishedReplyPageCount;
+      uint32_t mNumberOfPages, mPageSize, mIndexNextPage, mPublishedReplyPageCount, mReadReplyPageCount;
 
       //! The list of buffers still awaiting a reply
       std::deque < boost::shared_ptr< Buffers > > mReplyQueue;

--- a/uhal/uhal/src/common/ClientFactory.cpp
+++ b/uhal/uhal/src/common/ClientFactory.cpp
@@ -40,6 +40,7 @@
 #include "uhal/ProtocolTCP.hpp"
 #include "uhal/ProtocolIPbus.hpp"
 #include "uhal/ProtocolControlHub.hpp"
+#include "uhal/ProtocolMmap.hpp"
 #include "uhal/ProtocolPCIe.hpp"
 
 
@@ -76,6 +77,7 @@ namespace uhal
       mInstance->add< TCP< ControlHub < IPbus< 2 , 0 > > , 3 > > ( "chtcp-2.0", "Hardware access via the Control Hub, using IPbus version 2.0" );
       // ---------------------------------------------------------------------
       mInstance->add< PCIe > ( "ipbuspcie-2.0" , "Direct access to hardware via PCIe, using IPbus version 2.0" );
+      mInstance->add< Mmap > ( "ipbusmmap-2.0" , "Direct access to hardware via mmap, using IPbus version 2.0" );
       // ---------------------------------------------------------------------
 
     }

--- a/uhal/uhal/src/common/ProtocolMmap.cpp
+++ b/uhal/uhal/src/common/ProtocolMmap.cpp
@@ -1,0 +1,465 @@
+/*
+---------------------------------------------------------------------------
+
+    This file is part of uHAL.
+
+    uHAL is a hardware access library and programming framework
+    originally developed for upgrades of the Level-1 trigger of the CMS
+    experiment at CERN.
+
+    uHAL is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    uHAL is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with uHAL.  If not, see <http://www.gnu.org/licenses/>.
+
+
+      Andrew Rose, Imperial College, London
+      email: awr01 <AT> imperial.ac.uk
+
+      Marc Magrans de Abril, CERN
+      email: marc.magrans.de.abril <AT> cern.ch
+
+      Tom Williams, Rutherford Appleton Laboratory, Oxfordshire
+      email: tom.williams <AT> cern.ch
+
+---------------------------------------------------------------------------
+*/
+
+/**
+	@file
+	@author Tom Williams
+	@date September 2017
+*/
+
+#include "uhal/ProtocolMmap.hpp"
+
+
+#include <algorithm>                                        // for min
+#include <assert.h>
+#include <cstdlib>
+#include <fcntl.h>
+#include <iomanip>                                          // for operator<<
+#include <iostream>                                         // for operator<<
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <stdlib.h>                                         // for size_t, free
+#include <string.h>                                         // for memcpy
+#include <unistd.h>
+
+#include <boost/chrono/duration.hpp>                        // for operator>
+#include <boost/chrono/time_point.hpp>                      // for operator-
+#include <boost/lexical_cast.hpp>
+#include <boost/thread/thread.hpp>                          // for sleep_for
+#include <boost/date_time/posix_time/posix_time_types.hpp>  // for time_dura...
+
+#include "uhal/grammars/URI.hpp"                            // for URI
+#include "uhal/log/LogLevels.hpp"                           // for BaseLogLevel
+#include "uhal/log/log_inserters.integer.hpp"               // for Integer
+#include "uhal/log/log_inserters.quote.hpp"                 // for Quote
+#include "uhal/log/log.hpp"
+#include "uhal/Buffers.hpp"
+#include "uhal/ClientFactory.hpp"
+
+
+namespace uhal {
+
+
+Mmap::PacketFmt::PacketFmt(const uint8_t* const aPtr, const size_t aNrBytes) :
+  mData(1, std::pair<const uint8_t*, size_t>(aPtr, aNrBytes))
+{
+}
+
+Mmap::PacketFmt::PacketFmt(const std::vector< std::pair<const uint8_t*, size_t> >& aData) :
+  mData(aData)
+{}
+
+Mmap::PacketFmt::~PacketFmt()
+{}
+
+std::ostream& operator<<(std::ostream& aStream, const Mmap::PacketFmt& aPacket)
+{
+  std::ios::fmtflags lOrigFlags( aStream.flags() );
+
+  size_t lNrBytesWritten = 0;
+  for (size_t i = 0; i < aPacket.mData.size(); i++) {
+    for (const uint8_t* lPtr = aPacket.mData.at(i).first; lPtr != (aPacket.mData.at(i).first + aPacket.mData.at(i).second); lPtr++, lNrBytesWritten++) {
+      if ((lNrBytesWritten & 3) == 0)
+        aStream << std::endl << "   @ " << std::setw(3) << std::dec << (lNrBytesWritten >> 2) << " :  x";
+      aStream << std::setw(2) << std::hex << uint16_t(*lPtr) << " ";
+    }
+  }
+
+  aStream.flags( lOrigFlags );
+  return aStream;
+}
+
+
+
+
+Mmap::File::File(const std::string& aPath, int aFlags) :
+  mPath(aPath),
+  mFd(-1),
+  mFlags(aFlags),
+  mMmapBaseAddress(NULL)
+{
+}
+
+Mmap::File::~File()
+{
+  close();
+}
+
+const std::string& Mmap::File::getPath() const
+{
+  return mPath;
+}
+
+void Mmap::File::setPath(const std::string& aPath)
+{
+  mPath = aPath;
+}
+
+#define MAP_SIZE (32*1024UL)
+#define MAP_MASK (MAP_SIZE - 1)
+
+void Mmap::File::open()
+{
+  if (mFd != -1)
+    return;
+
+  mFd = ::open(mPath.c_str(), mFlags);
+  if ( mFd == -1 ) {
+    exception::MmapInitialisationError lExc;
+    log(lExc, "Failed to open device file ", Quote(mPath), "; errno=", Integer(errno), ", meaning ", Quote (strerror(errno)));
+    throw lExc;
+  }
+
+  mMmapBaseAddress = mmap(0, MAP_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, mFd, 0);
+  if (mMmapBaseAddress == (void *)-1) {
+    exception::MmapInitialisationError lExc;
+    log(lExc, "Error occurred when mapping device file '" + mPath + "' to memory; errno=", Integer(errno), ", meaning ", Quote (strerror(errno)));
+    throw lExc;
+  }
+}
+
+void Mmap::File::close()
+{
+  if (mMmapBaseAddress != NULL) {
+    if (munmap(mMmapBaseAddress, MAP_SIZE) == -1)
+      log ( Error() , "mmap client for ", Quote(mPath), " encountered error when unmapping memory" );
+  }
+
+  if (mFd != -1) {
+    int rc = ::close(mFd);
+    mFd = -1;
+    if (rc == -1)
+      log (Error(), "Failed to close file ", Quote(mPath), "; errno=", Integer(errno), ", meaning ", Quote (strerror(errno)));
+  }
+}
+
+
+void Mmap::File::read(const uint32_t aAddr, const uint32_t aNrWords, std::vector<uint32_t>& aValues)
+{
+  if (mFd == -1)
+    open();
+
+  uint8_t* lVirtAddr = static_cast<uint8_t*>(mMmapBaseAddress) + off_t(4*aAddr);
+
+  for (size_t i=0; i<aNrWords; i++) {
+    aValues.push_back(*((uint32_t*) (lVirtAddr + 4 * i)));
+  }
+
+  // aValues.insert(aValues.end(), reinterpret_cast<uint32_t*>(buffer), reinterpret_cast<uint32_t*>(buffer)+ aNrWords);
+}
+
+
+void Mmap::File::write(const uint32_t aAddr, const std::vector<std::pair<const uint8_t*, size_t> >& aData)
+{
+  if (mFd == -1)
+    open();
+
+  size_t lNrBytes = 0;
+  for (size_t i = 0; i < aData.size(); i++)
+    lNrBytes += aData.at(i).second;
+
+  assert((lNrBytes % 4) == 0);
+
+  char *allocated = NULL;
+  posix_memalign((void **)&allocated, 4096/*alignment*/, lNrBytes + 4096);
+  if (allocated == NULL) {
+    exception::MmapCommunicationError lExc;
+    log(lExc, "Failed to allocate ", Integer(lNrBytes + 4096), " bytes in File::write/2 function");
+    throw lExc;
+  }
+
+  // data to write to register address
+  char* buffer = allocated;
+  size_t lNrBytesCopied = 0;
+  for (size_t i = 0; i < aData.size(); i++) {
+    memcpy(buffer + lNrBytesCopied, aData.at(i).first, aData.at(i).second);
+    lNrBytesCopied += aData.at(i).second;
+  }
+
+//  memcpy(aMmapBaseAddress + aAddr, buffer, lNrBytes);
+  lNrBytesCopied = 0;
+  while (lNrBytesCopied < lNrBytes) {
+    char* lSrcPtr = buffer + lNrBytesCopied;
+    char* lVirtAddr = static_cast<char*>(mMmapBaseAddress) + aAddr + lNrBytesCopied;
+    if ((lNrBytes - lNrBytesCopied) >= 8) {
+      *((uint64_t*) lVirtAddr) = *(uint64_t*) lSrcPtr;
+      lNrBytesCopied += 8;
+    }
+    else if ((lNrBytes - lNrBytesCopied) >= 4) {
+      *((uint64_t*) lVirtAddr) = uint64_t(*(uint32_t*) lSrcPtr);
+      lNrBytesCopied += 4;
+    }
+  }
+
+  free(allocated);
+}
+
+
+
+
+Mmap::Mmap ( const std::string& aId, const URI& aUri ) :
+  IPbus< 2 , 0 > ( aId , aUri ),
+  mConnected(false),
+  mDeviceFile(aUri.mHostname, O_RDWR | O_SYNC),
+  mNumberOfPages(0),
+  mPageSize(0),
+  mIndexNextPage(0),
+  mPublishedReplyPageCount(0),
+  mReadReplyPageCount(0),
+  mAsynchronousException ( NULL )
+{
+  if ( getenv("UHAL_ENABLE_IPBUS_MMAP") == NULL ) {
+    exception::ProtocolDoesNotExist lExc;
+    log(lExc, "The IPbus 2.0 mmap client is still an experimental feature, since the software-driver interface could change in the future.");
+    log(lExc, "In order to enable the IPbus 2.0 mmap client, you need to define the environment variable 'UHAL_ENABLE_IPBUS_MMAP'");
+    throw lExc;
+  }
+
+  mSleepDuration = boost::chrono::microseconds(50);
+
+  for (NameValuePairVectorType::const_iterator lIt = aUri.mArguments.begin(); lIt != aUri.mArguments.end(); lIt++) {
+    if (lIt->first == "sleep") {
+      mSleepDuration = boost::chrono::microseconds(boost::lexical_cast<size_t>(lIt->second));
+      log (Notice() , "mmap client with URI ", Quote (uri()), " : Inter-poll-/-interrupt sleep duration set to ", boost::lexical_cast<size_t>(lIt->second), " us by URI 'sleep' attribute");
+    }
+    else
+      log (Warning() , "Unknown attribute ", Quote (lIt->first), " used in URI ", Quote(uri()));
+  }
+}
+
+
+Mmap::~Mmap()
+{
+  disconnect();
+}
+
+
+void Mmap::implementDispatch ( boost::shared_ptr< Buffers > aBuffers )
+{
+  log(Debug(), "mmap client (URI: ", Quote(uri()), ") : implementDispatch method called");
+
+  if ( ! mConnected )
+    connect();
+
+  if ( mReplyQueue.size() == mNumberOfPages )
+    read();
+  write(aBuffers);
+}
+
+
+void Mmap::Flush( )
+{
+  log(Debug(), "mmap client (URI: ", Quote(uri()), ") : Flush method called");
+  while ( !mReplyQueue.empty() )
+    read();
+
+}
+
+
+void Mmap::dispatchExceptionHandler()
+{
+  // FIXME: Adapt to PCIe implementation
+  log(Notice(), "mmap client ", Quote(id()), " (URI: ", Quote(uri()), ") : closing device files since exception detected");
+
+  ClientInterface::returnBufferToPool ( mReplyQueue );
+  disconnect();
+
+  InnerProtocol::dispatchExceptionHandler();
+}
+
+
+uint32_t Mmap::getMaxSendSize()
+{
+  if ( ! mConnected )
+    connect();
+
+  return (mPageSize - 1) * 4;
+}
+
+
+uint32_t Mmap::getMaxReplySize()
+{
+  if ( ! mConnected )
+    connect();
+
+  return (mPageSize - 1) * 4;
+}
+
+
+void Mmap::connect()
+{
+  log ( Debug() , "mmap client is opening device file " , Quote ( mDeviceFile.getPath() ) );
+  std::vector<uint32_t> lValues;
+  mDeviceFile.read(0x0, 4, lValues);
+  log (Info(), "Read status info from addr 0 (", Integer(lValues.at(0)), ", ", Integer(lValues.at(1)), ", ", Integer(lValues.at(2)), ", ", Integer(lValues.at(3)), "): ", PacketFmt((const uint8_t*)lValues.data(), 4 * lValues.size()));
+
+  mNumberOfPages = lValues.at(0);
+  mPageSize = std::min(uint32_t(4096), lValues.at(1));
+  mIndexNextPage = lValues.at(2);
+  mPublishedReplyPageCount = lValues.at(3);
+  mReadReplyPageCount = mPublishedReplyPageCount;
+
+  if (lValues.at(1) > 0xFFFF) {
+    exception::MmapInitialisationError lExc;
+    log (lExc, "Invalid page size, ", Integer(lValues.at(1)), ", reported in device file ", Quote(mDeviceFile.getPath()));
+    throw lExc;
+  }
+
+  if (mIndexNextPage >= mNumberOfPages) {
+    exception::MmapInitialisationError lExc;
+    log (lExc, "Next page index, ", Integer(mIndexNextPage), ", reported in device file ", Quote(mDeviceFile.getPath()), " is inconsistent with number of pages, ", Integer(mNumberOfPages));
+    throw lExc;
+  }
+
+  mConnected = true;
+  log ( Info() , "mmap client connected to device at ", Quote(mDeviceFile.getPath()), "; FPGA has ", Integer(mNumberOfPages), " pages, each of size ", Integer(mPageSize), " words, index ", Integer(mIndexNextPage), " should be filled next" );
+}
+
+
+void Mmap::disconnect()
+{
+  mDeviceFile.close();
+  mConnected = false;
+}
+
+
+void Mmap::write(const boost::shared_ptr<Buffers>& aBuffers)
+{
+  log (Info(), "mmap client ", Quote(id()), " (URI: ", Quote(uri()), ") : writing ", Integer(aBuffers->sendCounter() / 4), "-word packet to page ", Integer(mIndexNextPage), " in ", Quote(mDeviceFile.getPath()));
+
+  const uint32_t lHeaderWord = (0x10000 | (((aBuffers->sendCounter() / 4) - 1) & 0xFFFF));
+  std::vector<std::pair<const uint8_t*, size_t> > lDataToWrite;
+  lDataToWrite.push_back( std::make_pair(reinterpret_cast<const uint8_t*>(&lHeaderWord), sizeof lHeaderWord) );
+  lDataToWrite.push_back( std::make_pair(aBuffers->getSendBuffer(), aBuffers->sendCounter()) );
+  mDeviceFile.write(mIndexNextPage * 4 * mPageSize, lDataToWrite);
+
+  log (Debug(), "Wrote " , Integer((aBuffers->sendCounter() / 4) + 1), " 32-bit words at address " , Integer(mIndexNextPage * 4 * mPageSize), " ... ", PacketFmt(lDataToWrite));
+
+  mIndexNextPage = (mIndexNextPage + 1) % mNumberOfPages;
+  mReplyQueue.push_back(aBuffers);
+}
+
+
+// -------------------------------------------------------------------------------
+
+void Mmap::read()
+{
+  const size_t lPageIndexToRead = (mIndexNextPage - mReplyQueue.size() + mNumberOfPages) % mNumberOfPages;
+  SteadyClock_t::time_point lStartTime = SteadyClock_t::now();
+
+  if (mReadReplyPageCount == mPublishedReplyPageCount)
+  {
+    uint32_t lHwPublishedPageCount = 0x0;
+
+    while ( true ) {
+      std::vector<uint32_t> lValues;
+      // FIXME : Improve by simply adding dmaWrite method that takes uint32_t ref as argument (or returns uint32_t)
+      mDeviceFile.read(0, 4, lValues);
+      lHwPublishedPageCount = lValues.at(3);
+      log (Info(), "Read status info from addr 0 (", Integer(lValues.at(0)), ", ", Integer(lValues.at(1)), ", ", Integer(lValues.at(2)), ", ", Integer(lValues.at(3)), "): ", PacketFmt((const uint8_t*)lValues.data(), 4 * lValues.size()));
+
+      if (lHwPublishedPageCount != mPublishedReplyPageCount) {
+        mPublishedReplyPageCount = lHwPublishedPageCount;
+        break;
+      }
+      // FIXME: Throw if published page count is invalid number
+
+      if (SteadyClock_t::now() - lStartTime > boost::chrono::microseconds(getBoostTimeoutPeriod().total_microseconds())) {
+        exception::MmapTimeout lExc;
+        log(lExc, "Next page (index ", Integer(lPageIndexToRead), " count ", Integer(mPublishedReplyPageCount+1), ") of mmap device '" + mDeviceFile.getPath() + "' is not ready after timeout period");
+        throw lExc;
+      }
+
+      log(Debug(), "mmap client ", Quote(id()), " (URI: ", Quote(uri()), ") : Trying to read page index ", Integer(lPageIndexToRead), " = count ", Integer(mReadReplyPageCount+1), "; published page count is ", Integer(lHwPublishedPageCount), "; sleeping for ", mSleepDuration.count(), "us");
+      if (mSleepDuration > boost::chrono::microseconds(0))
+        boost::this_thread::sleep_for( mSleepDuration );
+    }
+
+    log(Info(), "mmap client ", Quote(id()), " (URI: ", Quote(uri()), ") : Reading page ", Integer(lPageIndexToRead), " (published count ", Integer(lHwPublishedPageCount), ", surpasses required, ", Integer(mReadReplyPageCount + 1), ")");
+  }
+  mReadReplyPageCount++;
+  
+  // PART 1 : Read the page
+  boost::shared_ptr<Buffers> lBuffers = mReplyQueue.front();
+  mReplyQueue.pop_front();
+
+  uint32_t lNrWordsToRead(lBuffers->replyCounter() >> 2);
+  lNrWordsToRead += 1;
+ 
+  std::vector<uint32_t> lPageContents;
+  mDeviceFile.read(4 + lPageIndexToRead * mPageSize, lNrWordsToRead , lPageContents);
+  log (Debug(), "Read " , Integer(lNrWordsToRead), " 32-bit words from address " , Integer(4 + lPageIndexToRead * 4 * mPageSize), " ... ", PacketFmt((const uint8_t*)lPageContents.data(), 4 * lPageContents.size()));
+
+  // PART 2 : Transfer to reply buffer
+  const std::deque< std::pair< uint8_t* , uint32_t > >& lReplyBuffers ( lBuffers->getReplyBuffer() );
+  size_t lNrWordsInPacket = (lPageContents.at(0) >> 16) + (lPageContents.at(0) & 0xFFFF);
+  if (lNrWordsInPacket != (lBuffers->replyCounter() >> 2))
+    log (Warning(), "Expected reply packet to contain ", Integer(lBuffers->replyCounter() >> 2), " words, but it actually contains ", Integer(lNrWordsInPacket), " words");
+
+  size_t lNrBytesCopied = 0;
+  for ( std::deque< std::pair< uint8_t* , uint32_t > >::const_iterator lIt = lReplyBuffers.begin() ; lIt != lReplyBuffers.end() ; ++lIt )
+  {
+    // Don't copy more of page than was written to, for cases when less data received than expected
+    if ( lNrBytesCopied >= 4*lNrWordsInPacket)
+      break;
+
+    size_t lNrBytesToCopy = std::min( lIt->second , uint32_t(4*lNrWordsInPacket - lNrBytesCopied) );
+    memcpy ( lIt->first, &lPageContents.at(1 + (lNrBytesCopied / 4)), lNrBytesToCopy );
+    lNrBytesCopied += lNrBytesToCopy;
+  }
+
+
+  // PART 3 : Validate the packet contents
+  try
+  {
+    if ( uhal::exception::exception* lExc = ClientInterface::validate ( lBuffers ) ) //Control of the pointer has been passed back to the client interface
+    {
+      mAsynchronousException = lExc;
+    }
+  }
+  catch ( exception::exception& aExc )
+  {
+    mAsynchronousException = new exception::ValidationError ();
+    log ( *mAsynchronousException , "Exception caught during reply validation for mmap device with URI " , Quote ( this->uri() ) , "; what returned: " , Quote ( aExc.what() ) );
+  }
+
+  if ( mAsynchronousException )
+  {
+    mAsynchronousException->ThrowAsDerivedType();
+  }
+}
+
+
+} // end ns uhal

--- a/uhal/uhal/src/common/ProtocolPCIe.cpp
+++ b/uhal/uhal/src/common/ProtocolPCIe.cpp
@@ -338,8 +338,9 @@ void PCIe::read()
     while ( true ) {
       std::vector<uint32_t> lValues;
       // FIXME : Improve by simply adding dmaWrite method that takes uint32_t ref as argument (or returns uint32_t)
-      dmaRead(mDeviceFileFPGAToHost, 3, (mXdma7seriesWorkaround ? 8 : 1), lValues);
-      lHwPublishedPageCount = lValues.at(0);
+      dmaRead(mDeviceFileFPGAToHost, 0, (mXdma7seriesWorkaround ? 8 : 4), lValues);
+      lHwPublishedPageCount = lValues.at(3);
+      log (Info(), "Read status info from addr 0 (", Integer(lValues.at(0)), ", ", Integer(lValues.at(1)), ", ", Integer(lValues.at(2)), ", ", Integer(lValues.at(3)), "): ", PacketFmt((const uint8_t*)lValues.data(), 4 * lValues.size()));
 
       if (lHwPublishedPageCount != mPublishedReplyPageCount) {
         mPublishedReplyPageCount++;
@@ -372,7 +373,7 @@ void PCIe::read()
   lNrWordsToRead += 1;
  
   std::vector<uint32_t> lPageContents;
-  dmaRead(mDeviceFileFPGAToHost, 4 + lPageIndexToRead * 4 * mPageSize, lNrWordsToRead , lPageContents);
+  dmaRead(mDeviceFileFPGAToHost, 4 + lPageIndexToRead * mPageSize, lNrWordsToRead , lPageContents);
   log (Debug(), "Read " , Integer(lNrWordsToRead), " 32-bit words from address " , Integer(4 + lPageIndexToRead * 4 * mPageSize), " ... ", PacketFmt((const uint8_t*)lPageContents.data(), 4 * lPageContents.size()));
 
   // PART 2 : Transfer to reply buffer

--- a/uhal/uhal/src/common/ProtocolPCIe.cpp
+++ b/uhal/uhal/src/common/ProtocolPCIe.cpp
@@ -45,6 +45,7 @@
 #include <algorithm>                                        // for min
 #include <assert.h>
 #include <cstdlib>
+#include <errno.h>
 #include <fcntl.h>
 #include <iomanip>                                          // for operator<<
 #include <iostream>                                         // for operator<<
@@ -70,13 +71,242 @@
 
 namespace uhal {
 
+
+PCIe::PacketFmt::PacketFmt(const uint8_t* const aPtr, const size_t aNrBytes) :
+  mData(1, std::pair<const uint8_t*, size_t>(aPtr, aNrBytes))
+{
+}
+
+PCIe::PacketFmt::PacketFmt(const std::vector< std::pair<const uint8_t*, size_t> >& aData) :
+  mData(aData)
+{}
+
+PCIe::PacketFmt::~PacketFmt()
+{}
+
+std::ostream& operator<<(std::ostream& aStream, const PCIe::PacketFmt& aPacket)
+{
+  std::ios::fmtflags lOrigFlags( aStream.flags() );
+
+  size_t lNrBytesWritten = 0;
+  for (size_t i = 0; i < aPacket.mData.size(); i++) {
+    for (const uint8_t* lPtr = aPacket.mData.at(i).first; lPtr != (aPacket.mData.at(i).first + aPacket.mData.at(i).second); lPtr++, lNrBytesWritten++) {
+      if ((lNrBytesWritten & 3) == 0)
+        aStream << std::endl << "   @ " << std::setw(3) << std::dec << (lNrBytesWritten >> 2) << " :  x";
+      aStream << std::setw(2) << std::hex << uint16_t(*lPtr) << " ";
+    }
+  }
+
+  aStream.flags( lOrigFlags );
+  return aStream;
+}
+
+
+
+
+PCIe::File::File(const std::string& aPath, int aFlags) :
+  mPath(aPath),
+  mFd(-1),
+  mFlags(aFlags)
+{
+}
+
+PCIe::File::~File()
+{
+  close();
+}
+
+const std::string& PCIe::File::getPath() const
+{
+  return mPath;
+}
+
+void PCIe::File::setPath(const std::string& aPath)
+{
+  mPath = aPath;
+}
+
+void PCIe::File::open()
+{
+  if (mFd != -1)
+    return;
+
+  mFd = ::open(mPath.c_str(), mFlags);
+  if ( mFd == -1 ) {
+    exception::PCIeInitialisationError lExc;
+    log(lExc, "Failed to open device file ", Quote(mPath), "; errno=", Integer(errno), ", meaning ", Quote (strerror(errno)));
+    throw lExc;
+  }
+}
+
+void PCIe::File::close()
+{
+  if (mFd != -1) {
+    int rc = ::close(mFd);
+    mFd = -1;
+    if (rc == -1)
+      log (Error(), "Failed to close file ", Quote(mPath), "; errno=", Integer(errno), ", meaning ", Quote (strerror(errno)));
+  }
+}
+
+
+void PCIe::File::read(const uint32_t aAddr, const uint32_t aNrWords, std::vector<uint32_t>& aValues)
+{
+  if (mFd == -1)
+    open();
+
+  char *allocated = NULL;
+  posix_memalign((void **)&allocated, 4096/*alignment*/, 4*aNrWords + 4096);
+  if (allocated == NULL) {
+    exception::PCIeCommunicationError lExc;
+    log(lExc, "Failed to allocate ", Integer(4*aNrWords + 4096), " bytes in File::read function");
+    throw lExc;
+  }
+
+  /* select AXI MM address */
+  char* buffer = allocated;
+  off_t off = lseek(mFd, 4*aAddr, SEEK_SET);
+  if ( off != (4 * aAddr)) {
+    exception::PCIeCommunicationError lExc;
+    log(lExc, "Offset returned by lseek, ", Integer(off), ", does not match that requested, ", Integer(4*aAddr), " (in preparation for read of ", Integer(aNrWords), " words)");
+    throw lExc;
+  }
+
+  /* read data from AXI MM into buffer using SGDMA */
+  int rc = ::read(mFd, buffer, 4*aNrWords);
+  if (rc == -1) {
+    exception::PCIeCommunicationError lExc;
+    log(lExc, "Read of ", Integer(4*aNrWords), " bytes at address ", Integer(4 * aAddr), " failed! errno=", Integer(errno), ", meaning ", Quote (strerror(errno)));
+    throw lExc;
+  }
+  else if (size_t(rc) < 4*aNrWords) {
+    exception::PCIeCommunicationError lExc;
+    log(lExc, "Only ", Integer(rc), " bytes transferred in read of ", Integer(4*aNrWords), " bytes at address ", Integer(4 * aAddr));
+    throw lExc;
+  }
+
+  aValues.insert(aValues.end(), reinterpret_cast<uint32_t*>(buffer), reinterpret_cast<uint32_t*>(buffer)+ aNrWords);
+
+  free(allocated);
+}
+
+
+void PCIe::File::write(const uint32_t aAddr, const std::vector<uint32_t>& aValues)
+{
+  write(4 * aAddr, reinterpret_cast<const uint8_t* const>(aValues.data()), 4 * aValues.size());
+}
+
+
+void PCIe::File::write(const uint32_t aAddr, const uint8_t* const aPtr, const size_t aNrBytes)
+{
+  if (mFd == -1)
+    open();
+
+  assert((aNrBytes % 4) == 0);
+
+  char *allocated = NULL;
+  posix_memalign((void **)&allocated, 4096/*alignment*/, aNrBytes + 4096);
+  if (allocated == NULL) {
+    exception::PCIeCommunicationError lExc;
+    log(lExc, "Failed to allocate ", Integer(aNrBytes + 4096), " bytes in File::write/3 function");
+    throw lExc;
+  }
+
+  // data to write to register address
+  char* buffer = allocated;
+  memcpy(buffer, aPtr, aNrBytes);
+
+  /* select AXI MM address */
+  off_t off = lseek(mFd, aAddr, SEEK_SET);
+  if ( off != aAddr) {
+    struct stat st;
+    if (fstat(mFd, &st) or (not S_ISFIFO(st.st_mode))) {
+      exception::PCIeCommunicationError lExc;
+      log(lExc, "Offset returned by lseek, ", Integer(off), ", does not match that requested, ", Integer(aAddr), " (in preparation for write of ", Integer(aNrBytes), " bytes)");
+      throw lExc;
+    }
+  }
+
+  /* write buffer to AXI MM address using SGDMA */
+  int rc = ::write(mFd, buffer, aNrBytes);
+  if (rc == -1) {
+    exception::PCIeCommunicationError lExc;
+    log(lExc, "Write of ", Integer(aNrBytes), " bytes at address ", Integer(aAddr), " failed! errno=", Integer(errno), ", meaning ", Quote (strerror(errno)));
+    throw lExc;
+  }
+  else if (size_t(rc) < aNrBytes) {
+    exception::PCIeCommunicationError lExc;
+    log(lExc, "Only ", Integer(rc), " bytes transferred in write of ", Integer(aNrBytes), " bytes at address ", Integer(aAddr));
+    throw lExc;
+  }
+
+  free(allocated);
+}
+
+
+void PCIe::File::write(const uint32_t aAddr, const std::vector<std::pair<const uint8_t*, size_t> >& aData)
+{
+  if (mFd == -1)
+    open();
+
+  size_t lNrBytes = 0;
+  for (size_t i = 0; i < aData.size(); i++)
+    lNrBytes += aData.at(i).second;
+
+  assert((lNrBytes % 4) == 0);
+
+  char *allocated = NULL;
+  posix_memalign((void **)&allocated, 4096/*alignment*/, lNrBytes + 4096);
+  if (allocated == NULL) {
+    exception::PCIeCommunicationError lExc;
+    log(lExc, "Failed to allocate ", Integer(lNrBytes + 4096), " bytes in File::write/2 function");
+    throw lExc;
+  }
+
+  // data to write to register address
+  char* buffer = allocated;
+  size_t lNrBytesCopied = 0;
+  for (size_t i = 0; i < aData.size(); i++) {
+    memcpy(buffer + lNrBytesCopied, aData.at(i).first, aData.at(i).second);
+    lNrBytesCopied += aData.at(i).second;
+  }
+
+  /* select AXI MM address */
+  off_t off = lseek(mFd, aAddr, SEEK_SET);
+  if ( off != aAddr) {
+    struct stat st;
+    if (fstat(mFd, &st) or (not S_ISFIFO(st.st_mode))) {
+      exception::PCIeCommunicationError lExc;
+      log(lExc, "Offset returned by lseek, ", Integer(off), ", does not match that requested, ", Integer(aAddr), " (in preparation for write of ", Integer(lNrBytes), " bytes)");
+      throw lExc;
+    }
+  }
+
+  /* write buffer to AXI MM address using SGDMA */
+  int rc = ::write(mFd, buffer, lNrBytes);
+  if (rc == -1) {
+    exception::PCIeCommunicationError lExc;
+    log(lExc, "Write of ", Integer(lNrBytes), " bytes at address ", Integer(aAddr), " failed! errno=", Integer(errno), ", meaning ", Quote (strerror(errno)));
+    throw lExc;
+  }
+  else if (size_t(rc) < lNrBytes) {
+    exception::PCIeCommunicationError lExc;
+    log(lExc, "Only ", Integer(rc), " bytes transferred in write of ", Integer(lNrBytes), " bytes at address ", Integer(aAddr));
+    throw lExc;
+  }
+
+  free(allocated);
+}
+
+
+
+
 PCIe::PCIe ( const std::string& aId, const URI& aUri ) :
   IPbus< 2 , 0 > ( aId , aUri ),
-  mDevicePathHostToFPGA(aUri.mHostname.substr(0, aUri.mHostname.find(","))),
-  mDevicePathFPGAToHost(aUri.mHostname.substr(aUri.mHostname.find(",")+1)),
-  mDeviceFileHostToFPGA(-1),
-  mDeviceFileFPGAToHost(-1),
-  mDeviceFileFPGAEvent(-1),
+  mConnected(false),
+  mDeviceFileHostToFPGA(aUri.mHostname.substr(0, aUri.mHostname.find(",")), O_RDWR ),
+  mDeviceFileFPGAToHost(aUri.mHostname.substr(aUri.mHostname.find(",")+1), O_RDWR | O_NONBLOCK  /* for read might need O_RDWR | O_NONBLOCK */),
+  mDeviceFileFPGAEvent("", O_RDONLY),
   mXdma7seriesWorkaround(false),
   mUseInterrupt(false),
   mNumberOfPages(0),
@@ -115,7 +345,7 @@ PCIe::PCIe ( const std::string& aId, const URI& aUri ) :
       }
 
       mUseInterrupt = true;
-      mDevicePathFPGAEvent = lIt->second;
+      mDeviceFileFPGAEvent.setPath(lIt->second);
       log (Info() , "PCIe client with URI ", Quote (uri()), " is configured to use interrupts");
     }
     else if (lIt->first == "sleep") {
@@ -142,7 +372,7 @@ void PCIe::implementDispatch ( boost::shared_ptr< Buffers > aBuffers )
 {
   log(Debug(), "PCIe client (URI: ", Quote(uri()), ") : implementDispatch method called");
 
-  if ( (mDeviceFileFPGAToHost < 0) && (mDeviceFileHostToFPGA < 0) )
+  if ( ! mConnected )
     connect();
 
   if ( mReplyQueue.size() == mNumberOfPages )
@@ -174,7 +404,7 @@ void PCIe::dispatchExceptionHandler()
 
 uint32_t PCIe::getMaxSendSize()
 {
-  if ( (mDeviceFileFPGAToHost < 0) && (mDeviceFileHostToFPGA < 0) )
+  if ( ! mConnected )
     connect();
 
   return (mPageSize - 1) * 4;
@@ -183,7 +413,7 @@ uint32_t PCIe::getMaxSendSize()
 
 uint32_t PCIe::getMaxReplySize()
 {
-  if ( (mDeviceFileFPGAToHost < 0) && (mDeviceFileHostToFPGA < 0) )
+  if ( ! mConnected )
     connect();
 
   return (mPageSize - 1) * 4;
@@ -192,26 +422,13 @@ uint32_t PCIe::getMaxReplySize()
 
 void PCIe::connect()
 {
-  log ( Debug() , "PCIe client is opening device file " , Quote ( mDevicePathHostToFPGA ) , " (client-to-device)" );
+  log ( Debug() , "PCIe client is opening device file " , Quote ( mDeviceFileHostToFPGA.getPath() ) , " (client-to-device)" );
+  mDeviceFileHostToFPGA.open();
 
-  mDeviceFileHostToFPGA = open(mDevicePathHostToFPGA.c_str(), O_RDWR );
-  if ( mDeviceFileHostToFPGA < 0 ) {
-    exception::PCIeInitialisationError lExc;
-    log(lExc, "Cannot open host-to-FPGA device file '" + mDevicePathHostToFPGA + "'");
-    throw lExc;
-  }
-
-
-  log ( Debug() , "PCIe client is opening device file " , Quote ( mDevicePathFPGAToHost ) , " (device-to-client)" );
-  mDeviceFileFPGAToHost = open(mDevicePathFPGAToHost.c_str(), O_RDWR | O_NONBLOCK  /* for read might need O_RDWR | O_NONBLOCK */ );
-  if ( mDeviceFileFPGAToHost < 0 ) {
-    exception::PCIeInitialisationError lExc;
-    log(lExc, "Cannot open FPGA-to-host device file '" + mDevicePathFPGAToHost + "'");
-    throw lExc;
-  }
-
+  log ( Debug() , "PCIe client is opening device file " , Quote ( mDeviceFileFPGAToHost.getPath() ) , " (device-to-client)" );
   std::vector<uint32_t> lValues;
-  dmaRead(mDeviceFileFPGAToHost, 0x0, 4, lValues);
+  mDeviceFileFPGAToHost.read(0x0, 4, lValues);
+  log (Info(), "Read status info from addr 0 (", Integer(lValues.at(0)), ", ", Integer(lValues.at(1)), ", ", Integer(lValues.at(2)), ", ", Integer(lValues.at(3)), "): ", PacketFmt((const uint8_t*)lValues.data(), 4 * lValues.size()));
 
   mNumberOfPages = lValues.at(0);
   mPageSize = std::min(uint32_t(4096), lValues.at(1));
@@ -219,80 +436,47 @@ void PCIe::connect()
   mPublishedReplyPageCount = lValues.at(3);
   mReadReplyPageCount = mPublishedReplyPageCount;
 
-
-  if (mUseInterrupt) {
-    mDeviceFileFPGAEvent = open(mDevicePathFPGAEvent.c_str(), O_RDONLY);
-    if ( mDeviceFileFPGAEvent < 0 ) {
-      exception::PCIeInitialisationError lExc;
-      log(lExc, "Cannot open 'interrupt event' device file '" + mDevicePathFPGAEvent + "'");
-      throw lExc;
-    }
+  if (lValues.at(1) > 0xFFFF) {
+    exception::PCIeInitialisationError lExc;
+    log (lExc, "Invalid page size, ", Integer(lValues.at(1)), ", reported in device file ", Quote(mDeviceFileFPGAToHost.getPath()));
+    throw lExc;
   }
 
-  log ( Info() , "PCIe client connected to device at ", Quote(mDevicePathHostToFPGA), ", ", Quote(mDevicePathFPGAToHost), "; FPGA has ", Integer(mNumberOfPages), " pages, each of size ", Integer(mPageSize), " words, index ", Integer(mIndexNextPage), " should be filled next" );
+  if (mIndexNextPage >= mNumberOfPages) {
+    exception::PCIeInitialisationError lExc;
+    log (lExc, "Next page index, ", Integer(mIndexNextPage), ", reported in device file ", Quote(mDeviceFileFPGAToHost.getPath()), " is inconsistent with number of pages, ", Integer(mNumberOfPages));
+    throw lExc;
+  }
+
+  if (mUseInterrupt)
+    mDeviceFileFPGAEvent.open();
+
+  mConnected = true;
+  log ( Info() , "PCIe client connected to device at ", Quote(mDeviceFileHostToFPGA.getPath()), ", ", Quote(mDeviceFileFPGAToHost.getPath()), "; FPGA has ", Integer(mNumberOfPages), " pages, each of size ", Integer(mPageSize), " words, index ", Integer(mIndexNextPage), " should be filled next" );
 }
 
 
 void PCIe::disconnect()
 {
-  // FIXME: Add proper implementation
-  mDeviceFileHostToFPGA = -1;
-  mDeviceFileFPGAToHost = -1;
-  mDeviceFileFPGAEvent = -1;
+  mDeviceFileHostToFPGA.close();
+  mDeviceFileFPGAToHost.close();
+  mDeviceFileFPGAEvent.close();
+  mConnected = false;
 }
 
-
-class PacketFmt {
-public:
-  PacketFmt(const uint8_t* const, const size_t);
-  PacketFmt(const std::vector< std::pair<const uint8_t*, size_t> >& aData);
-  ~PacketFmt();
-
-  const std::vector< std::pair<const uint8_t*, size_t> > mData;
-};
-
-PacketFmt::PacketFmt(const uint8_t* const aPtr, const size_t aNrBytes) :
-  mData(1, std::pair<const uint8_t*, size_t>(aPtr, aNrBytes))
-{
-   // mData.push_back(std::pair<const uint8_t*, size_t>(aPtr, aNrBytes));
-}
-
-PacketFmt::PacketFmt(const std::vector< std::pair<const uint8_t*, size_t> >& aData) :
-  mData(aData)
-{}
-
-PacketFmt::~PacketFmt()
-{}
-
-std::ostream& operator<<(std::ostream& aStream, const PacketFmt& aPacket)
-{
-  std::ios::fmtflags lOrigFlags( aStream.flags() );
-
-  size_t lNrBytesWritten = 0;
-  for (size_t i = 0; i < aPacket.mData.size(); i++) {
-    for (const uint8_t* lPtr = aPacket.mData.at(i).first; lPtr != (aPacket.mData.at(i).first + aPacket.mData.at(i).second); lPtr++, lNrBytesWritten++) {
-      if ((lNrBytesWritten & 3) == 0)
-        aStream << std::endl << "   @ " << std::setw(3) << std::dec << (lNrBytesWritten >> 2) << " :  x";
-      aStream << std::setw(2) << std::hex << uint16_t(*lPtr) << " ";
-    }
-  }
-
-  aStream.flags( lOrigFlags );
-  return aStream;
-}
 
 
 void PCIe::write(const boost::shared_ptr<Buffers>& aBuffers)
 {
-  log (Info(), "PCIe client ", Quote(id()), " (URI: ", Quote(uri()), ") : writing ", Integer(aBuffers->sendCounter() / 4), "-word packet to page ", Integer(mIndexNextPage), " in ", Quote(mDevicePathHostToFPGA));
+  log (Info(), "PCIe client ", Quote(id()), " (URI: ", Quote(uri()), ") : writing ", Integer(aBuffers->sendCounter() / 4), "-word packet to page ", Integer(mIndexNextPage), " in ", Quote(mDeviceFileHostToFPGA.getPath()));
 
   const uint32_t lHeaderWord = (0x10000 | (((aBuffers->sendCounter() / 4) - 1) & 0xFFFF));
   std::vector<std::pair<const uint8_t*, size_t> > lDataToWrite;
   lDataToWrite.push_back( std::make_pair(reinterpret_cast<const uint8_t*>(&lHeaderWord), sizeof lHeaderWord) );
   lDataToWrite.push_back( std::make_pair(aBuffers->getSendBuffer(), aBuffers->sendCounter()) );
-  dmaWrite(mDeviceFileHostToFPGA, mIndexNextPage * 4 * mPageSize, lDataToWrite);
+  mDeviceFileHostToFPGA.write(mIndexNextPage * 4 * mPageSize, lDataToWrite);
 
-  log (Debug(), "Writing " , Integer((aBuffers->sendCounter() / 4) + 1), " 32-bit words at address " , Integer(mIndexNextPage * 4 * mPageSize), " ... ", PacketFmt(lDataToWrite));
+  log (Debug(), "Wrote " , Integer((aBuffers->sendCounter() / 4) + 1), " 32-bit words at address " , Integer(mIndexNextPage * 4 * mPageSize), " ... ", PacketFmt(lDataToWrite));
 
   mIndexNextPage = (mIndexNextPage + 1) % mNumberOfPages;
   mReplyQueue.push_back(aBuffers);
@@ -310,19 +494,18 @@ void PCIe::read()
   {
     if (mUseInterrupt)
     {
-      uint32_t lRxEvent = 0;
+      std::vector<uint32_t> lRxEvent;
       // wait for interrupt; read events file node to see if user interrupt has come
       while (true) {
-        lRxEvent = 0;
-
-        ::read(mDeviceFileFPGAEvent, &lRxEvent, 4);
-        if (lRxEvent == 1) {
+        mDeviceFileFPGAEvent.read(0, 1, lRxEvent);
+        if (lRxEvent.at(0) == 1) {
           break;
         }
+        lRxEvent.clear();
 
         if (SteadyClock_t::now() - lStartTime > boost::chrono::microseconds(getBoostTimeoutPeriod().total_microseconds())) {
           exception::PCIeTimeout lExc;
-          log(lExc, "Next page (index ", Integer(lPageIndexToRead), " count ", Integer(mPublishedReplyPageCount+1), ") of PCIe device '" + mDevicePathHostToFPGA + "' is not ready after timeout period");
+          log(lExc, "Next page (index ", Integer(lPageIndexToRead), " count ", Integer(mPublishedReplyPageCount+1), ") of PCIe device '" + mDeviceFileHostToFPGA.getPath() + "' is not ready after timeout period");
           throw lExc;
         }
 
@@ -340,10 +523,10 @@ void PCIe::read()
 
       while ( true ) {
         std::vector<uint32_t> lValues;
-        // FIXME : Improve by simply adding dmaWrite method that takes uint32_t ref as argument (or returns uint32_t)
-        dmaRead(mDeviceFileFPGAToHost, 0, (mXdma7seriesWorkaround ? 8 : 4), lValues);
+        // FIXME : Improve by simply adding fileWrite method that takes uint32_t ref as argument (or returns uint32_t)
+        mDeviceFileFPGAToHost.read(0, (mXdma7seriesWorkaround ? 8 : 4), lValues);
         lHwPublishedPageCount = lValues.at(3);
-        log (Info(), "Read status info from addr 0 (", Integer(lValues.at(0)), ", ", Integer(lValues.at(1)), ", ", Integer(lValues.at(2)), ", ", Integer(lValues.at(3)), "): ", PacketFmt((const uint8_t*)lValues.data(), 4 * lValues.size()));
+        log (Debug(), "Read status info from addr 0 (", Integer(lValues.at(0)), ", ", Integer(lValues.at(1)), ", ", Integer(lValues.at(2)), ", ", Integer(lValues.at(3)), "): ", PacketFmt((const uint8_t*)lValues.data(), 4 * lValues.size()));
 
         if (lHwPublishedPageCount != mPublishedReplyPageCount) {
           mPublishedReplyPageCount = lHwPublishedPageCount;
@@ -353,7 +536,7 @@ void PCIe::read()
 
         if (SteadyClock_t::now() - lStartTime > boost::chrono::microseconds(getBoostTimeoutPeriod().total_microseconds())) {
           exception::PCIeTimeout lExc;
-          log(lExc, "Next page (index ", Integer(lPageIndexToRead), " count ", Integer(mPublishedReplyPageCount+1), ") of PCIe device '" + mDevicePathHostToFPGA + "' is not ready after timeout period");
+          log(lExc, "Next page (index ", Integer(lPageIndexToRead), " count ", Integer(mPublishedReplyPageCount+1), ") of PCIe device '" + mDeviceFileHostToFPGA.getPath() + "' is not ready after timeout period");
           throw lExc;
         }
 
@@ -377,7 +560,7 @@ void PCIe::read()
   lNrWordsToRead += 1;
  
   std::vector<uint32_t> lPageContents;
-  dmaRead(mDeviceFileFPGAToHost, 4 + lPageIndexToRead * mPageSize, lNrWordsToRead , lPageContents);
+  mDeviceFileFPGAToHost.read(4 + lPageIndexToRead * mPageSize, lNrWordsToRead , lPageContents);
   log (Debug(), "Read " , Integer(lNrWordsToRead), " 32-bit words from address " , Integer(4 + lPageIndexToRead * 4 * mPageSize), " ... ", PacketFmt((const uint8_t*)lPageContents.data(), 4 * lPageContents.size()));
 
   // PART 2 : Transfer to reply buffer
@@ -417,122 +600,6 @@ void PCIe::read()
   {
     mAsynchronousException->ThrowAsDerivedType();
   }
-}
-
-
-void PCIe::dmaRead(int aFileDescriptor, const uint32_t aAddr, const uint32_t aNrWords, std::vector<uint32_t>& aValues)
-{
-  char *allocated = NULL;
-  posix_memalign((void **)&allocated, 4096/*alignment*/, 4*aNrWords + 4096);
-  assert(allocated);
-
-  /* select AXI MM address */
-  char* buffer = allocated;
-  off_t off = lseek(aFileDescriptor, 4*aAddr, SEEK_SET);
-  if ( off != (4 * aAddr)) {
-    exception::PCIeCommunicationError lExc;
-    log(lExc, "Offset returned by lseek, ", Integer(off), ", does not match that requested, ", Integer(4*aAddr), " (in preparation for read of ", Integer(aNrWords), " words)");
-    throw lExc;
-  }
-
-  /* read data from AXI MM into buffer using SGDMA */
-  int rc = ::read(aFileDescriptor, buffer, 4*aNrWords);
-  assert(rc >= 0);
-  assert((rc % 4) == 0);
-  if ((rc > 0) && (size_t(rc) < 4*aNrWords)) {
-    std::cout << "Short read of " << rc << " bytes into a " << 4*aNrWords << " bytes buffer, could be a packet read?\n";
-  }
-
-  aValues.insert(aValues.end(), reinterpret_cast<uint32_t*>(buffer), reinterpret_cast<uint32_t*>(buffer)+ aNrWords);
-//    for (unsigned i=0; i<aNrWords; i++) {
-//      //uint32_t val = (buffer[4*i]&0xff)+((buffer[4*i+1]&0xff)<<8)+((buffer[4*i+2]&0xff)<<16)
-//      //  +((buffer[4*i+3]&0xff)<<24);
-//      uint32_t val = *reinterpret_cast<uint32_t*>(buffer);
-//      printf("ipbus address : 0x%08x\n", aAddr);
-//      printf("readback value: 0x%08x\n\n",val);
-//    }
-
-  free(allocated);
-}
-
-
-bool PCIe::dmaWrite(int aFileDescriptor, const uint32_t aAddr, const std::vector<uint32_t>& aValues)
-{
-  return dmaWrite(aFileDescriptor, 4 * aAddr, reinterpret_cast<const uint8_t* const>(aValues.data()), 4 * aValues.size());
-}
-
-
-bool PCIe::dmaWrite(int aFileDescriptor, const uint32_t aAddr, const uint8_t* const aPtr, const size_t aNrBytes)
-{
-  assert((aNrBytes % 4) == 0);
-
-  char *allocated = NULL;
-  posix_memalign((void **)&allocated, 4096/*alignment*/, aNrBytes + 4096);
-  assert(allocated);
-
-  // data to write to register address
-  char* buffer = allocated;
-  memcpy(buffer, aPtr, aNrBytes);
-
-  /* select AXI MM address */
-  off_t off = lseek(aFileDescriptor, aAddr, SEEK_SET);
-  if ( off != aAddr) {
-    struct stat st;
-    if (fstat(aFileDescriptor, &st) or (not S_ISFIFO(st.st_mode))) {
-      exception::PCIeCommunicationError lExc;
-      log(lExc, "Offset returned by lseek, ", Integer(off), ", does not match that requested, ", Integer(aAddr), " (in preparation for write of ", Integer(aNrBytes), " bytes)");
-      throw lExc;
-    }
-  }
-
-  /* write buffer to AXI MM address using SGDMA */
-  int rc = ::write(aFileDescriptor, buffer, aNrBytes);
-  assert((rc > 0) && (size_t(rc) == aNrBytes));
-
-  free(allocated);
-
-  return true;
-}
-
-
-bool PCIe::dmaWrite(int aFileDescriptor, const uint32_t aAddr, const std::vector<std::pair<const uint8_t*, size_t> >& aData)
-{
-  size_t lNrBytes = 0;
-  for (size_t i = 0; i < aData.size(); i++)
-    lNrBytes += aData.at(i).second;
-
-  assert((lNrBytes % 4) == 0);
-
-  char *allocated = NULL;
-  posix_memalign((void **)&allocated, 4096/*alignment*/, lNrBytes + 4096);
-  assert(allocated);
-
-  // data to write to register address
-  char* buffer = allocated;
-  size_t lNrBytesCopied = 0;
-  for (size_t i = 0; i < aData.size(); i++) {
-    memcpy(buffer + lNrBytesCopied, aData.at(i).first, aData.at(i).second);
-    lNrBytesCopied += aData.at(i).second;
-  }
-
-  /* select AXI MM address */
-  off_t off = lseek(aFileDescriptor, aAddr, SEEK_SET);
-  if ( off != aAddr) {
-    struct stat st;
-    if (fstat(aFileDescriptor, &st) or (not S_ISFIFO(st.st_mode))) {
-      exception::PCIeCommunicationError lExc;
-      log(lExc, "Offset returned by lseek, ", Integer(off), ", does not match that requested, ", Integer(aAddr), " (in preparation for write of ", Integer(lNrBytes), " bytes)");
-      throw lExc;
-    }
-  }
-
-  /* write buffer to AXI MM address using SGDMA */
-  int rc = ::write(aFileDescriptor, buffer, lNrBytes);
-  assert((rc > 0) && (size_t(rc) == lNrBytes));
-
-  free(allocated);
-
-  return true;
 }
 
 

--- a/uhal/uhal/src/common/ProtocolPCIe.cpp
+++ b/uhal/uhal/src/common/ProtocolPCIe.cpp
@@ -392,7 +392,6 @@ void PCIe::Flush( )
 
 void PCIe::dispatchExceptionHandler()
 {
-  // FIXME: Adapt to PCIe implementation
   log(Notice(), "PCIe client ", Quote(id()), " (URI: ", Quote(uri()), ") : closing device files since exception detected");
 
   ClientInterface::returnBufferToPool ( mReplyQueue );


### PR DESCRIPTION
This pull request contains PCIe-related improvements (as part of issue #83). Specifically, it:
 * Fixes a bug in the client that affected multiple-packet-in-flight operation.
 * Reorganises the existing PCIe client that uses the C `read` and `write` functions to communicate with the device
 * Introduces a new client that reads/writes devices files using `mmap` 