### PR TITLE
Fix compilation issues on non English systems and with Boost 1.69

### DIFF
--- a/uhal/config/mfCommonDefs.mk
+++ b/uhal/config/mfCommonDefs.mk
@@ -32,7 +32,7 @@ ifneq (,$(wildcard ${EXTERN_BOOST_LIB_PREFIX}/libboost_thread-mt.so ${EXTERN_BOO
   BOOST_THREAD_LIB = boost_thread-mt
 else ifneq (,$(wildcard ${EXTERN_BOOST_LIB_PREFIX}/libboost_thread.so ${EXTERN_BOOST_LIB_PREFIX}/libboost_thread.dylib))
   BOOST_THREAD_LIB = boost_thread
-else ifeq (,$(shell ${CPP} -lboost_thread-mt 2>&1 | grep -E 'ld: (cannot find|library not found)'))
+else ifeq (,$(shell LANG=C ${CPP} -lboost_thread-mt 2>&1 | grep -E 'ld: (cannot find|library not found)'))
   BOOST_THREAD_LIB = boost_thread-mt
 else
   BOOST_THREAD_LIB = boost_thread

--- a/uhal/uhal/include/uhal/ClientFactory.hpp
+++ b/uhal/uhal/include/uhal/ClientFactory.hpp
@@ -46,6 +46,7 @@
 
 #include <boost/shared_ptr.hpp>
 #include <boost/unordered_map.hpp>
+#include <boost/noncopyable.hpp>
 
 #include <map>
 

--- a/uhal/uhal/include/uhal/ConnectionManager.hpp
+++ b/uhal/uhal/include/uhal/ConnectionManager.hpp
@@ -45,6 +45,7 @@
 #include "uhal/HwInterface.hpp"
 
 #include <boost/filesystem/path.hpp>
+#include <boost/noncopyable.hpp>
 
 #include <vector>
 #include <set>


### PR DESCRIPTION
The two issues were:

* Relying on the output of a potentially localized command (`${CXX}`)
* Missing `#includes <boost/noncopyable.hpp>` (was probably included through other headers before)

Compilation was tested on Arch Linux with GCC 8.2.1 and completed without errors.