### PR TITLE
Resolve runtime errors with boost 1.69 and Erlang 21

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -117,14 +117,12 @@ build:centos7:
     when: always
     expire_in: 1 day
 
-build:fedora26:
+build:fedora30-python2:
   <<: *simple_build_jobTemplate
-  image: ${IPBUS_DOCKER_REGISTRY}/ipbus-sw-dev-fedora26:2019-01-08__erlang19.3_gcc7.1.1_boost1.63.0_pugixml1.8
-
-build:fedora26-python3:
+  image: ${IPBUS_DOCKER_REGISTRY}/ipbus-sw-dev-fedora30-python2:2019-10-12__erlang21.3_gcc9.2.1_boost1.69.0_pugixml1.9
+build:fedora30-python3:
   <<: *simple_build_jobTemplate
-  image: ${IPBUS_DOCKER_REGISTRY}/ipbus-sw-dev-fedora26-python3:2019-01-08__erlang19.3_gcc7.1.1_boost1.63.0_pugixml1.8
-
+  image: ${IPBUS_DOCKER_REGISTRY}/ipbus-sw-dev-fedora30-python3:2019-10-12__erlang21.3_gcc9.2.1_boost1.69.0_pugixml1.9
 build:ubuntu16:
   <<: *simple_build_jobTemplate
   image: ${IPBUS_DOCKER_REGISTRY}/ipbus-sw-dev-ubuntu16:2019-01-08__erlang18.3_gcc5.3.1_boost1.58.0_pugixml1.7
@@ -194,21 +192,21 @@ publish_build_job:
     - ls -al /opt/cactus /opt/cactus/*
     - export TEST_SUITE_CONTROLHUB_PATH_ARGUMENT="-p /opt/cactus/bin"
 
-.job_template: &fedora26_test_jobTemplate
+.job_template: &fedora30_python2_test_jobTemplate
   <<: *simpleInstall_test_jobTemplate
-  image: ${IPBUS_DOCKER_REGISTRY}/ipbus-sw-dev-fedora26:2019-01-08__erlang19.3_gcc7.1.1_boost1.63.0_pugixml1.8
+  image: ${IPBUS_DOCKER_REGISTRY}/ipbus-sw-dev-fedora30-python2:2019-10-12__erlang21.3_gcc9.2.1_boost1.69.0_pugixml1.9
   dependencies:
-    - build:fedora26
+    - build:fedora30-python2
   variables:
     UHAL_ENABLE_IPBUS_PCIE: ""
     UHAL_GUI_DEPENDENCIES: "wxPython numpy"
     VALGRIND_ARGS: "--suppressions=/opt/cactus/etc/uhal/tests/valgrind/uhal_tests.supp"
 
-.job_template: &fedora26_python3_test_jobTemplate
+.job_template: &fedora30_python3_test_jobTemplate
   <<: *simpleInstall_test_jobTemplate
-  image: ${IPBUS_DOCKER_REGISTRY}/ipbus-sw-dev-fedora26-python3:2019-01-08__erlang19.3_gcc7.1.1_boost1.63.0_pugixml1.8
+  image: ${IPBUS_DOCKER_REGISTRY}/ipbus-sw-dev-fedora30-python3:2019-10-12__erlang21.3_gcc9.2.1_boost1.69.0_pugixml1.9
   dependencies:
-    - build:fedora26-python3
+    - build:fedora30-python3
   variables:
     UHAL_ENABLE_IPBUS_PCIE: ""
     UHAL_GUI_DEPENDENCIES: python3-wxpython4
@@ -326,45 +324,45 @@ test_controlhub:centos7:
   <<: *test_controlhub_plainScripts_jobTemplate
 
 
-test_core:fedora26:
-  <<: *fedora26_test_jobTemplate
+test_core:fedora30-python2:
+  <<: *fedora30_python2_test_jobTemplate
   <<: *test_core_jobTemplate
 
-test_python:fedora26:
-  <<: *fedora26_test_jobTemplate
+test_python:fedora30-python2:
+  <<: *fedora30_python2_test_jobTemplate
   <<: *test_python_jobTemplate
 
-test_gui:fedora26:
-  <<: *fedora26_test_jobTemplate
+test_gui:fedora30-python2:
+  <<: *fedora30_python2_test_jobTemplate
   <<: *test_gui_jobTemplate
 
-test_tools:fedora26:
-  <<: *fedora26_test_jobTemplate
+test_tools:fedora30-python2:
+  <<: *fedora30_python2_test_jobTemplate
   <<: *test_tools_jobTemplate
 
-test_controlhub:fedora26:
-  <<: *fedora26_test_jobTemplate
+test_controlhub:fedora30-python2:
+  <<: *fedora30_python2_test_jobTemplate
   <<: *test_controlhub_plainScripts_jobTemplate
 
 
-test_core:fedora26-python3:
-  <<: *fedora26_python3_test_jobTemplate
+test_core:fedora30-python3:
+  <<: *fedora30_python3_test_jobTemplate
   <<: *test_core_jobTemplate
 
-test_python:fedora26-python3:
-  <<: *fedora26_python3_test_jobTemplate
+test_python:fedora30-python3:
+  <<: *fedora30_python3_test_jobTemplate
   <<: *test_python_jobTemplate
 
-test_gui:fedora26-python3:
-  <<: *fedora26_python3_test_jobTemplate
+test_gui:fedora30-python3:
+  <<: *fedora30_python3_test_jobTemplate
   <<: *test_gui_jobTemplate
 
-test_tools:fedora26-python3:
-  <<: *fedora26_python3_test_jobTemplate
+test_tools:fedora30-python3:
+  <<: *fedora30_python3_test_jobTemplate
   <<: *test_tools_jobTemplate
 
-test_controlhub:fedora26-python3:
-  <<: *fedora26_python3_test_jobTemplate
+test_controlhub:fedora30-python3:
+  <<: *fedora30_python3_test_jobTemplate
   <<: *test_controlhub_plainScripts_jobTemplate
 
 

--- a/controlhub/rebar.config
+++ b/controlhub/rebar.config
@@ -23,5 +23,6 @@
             % Use new time API from Erlang version 18
             % (Erlang releases from 17 onwards do not put R in front of name
             {platform_define, "^(R|17).*", old_erlang_time_api},
-            {platform_define, "^(R|17|18).*", orig_udp_port_command_format}
+            {platform_define, "^(R|17|18).*", orig_udp_port_command_format},
+            {platform_define, "^(R|17|18|19).*", bypass_gen_udp_send}
             ]}.

--- a/controlhub/src/ch_device_client.erl
+++ b/controlhub/src/ch_device_client.erl
@@ -841,8 +841,7 @@ udp_proc_loop(Socket, IP, Port, ParentPid) ->
     after 0 ->
         receive 
             {send, Pkt} ->
-                {IP1, IP2, IP3, IP4} = IP,
-                true = erlang:port_command(Socket, [?GEN_UDP_PORT_COMMAND_PREFIX, [((Port) bsr 8) band 16#ff, (Port) band 16#ff], [IP1 band 16#ff, IP2 band 16#ff, IP3 band 16#ff, IP4 band 16#ff], Pkt]);
+                udp_send(Socket, IP, Port, Pkt);
             {inet_reply, Socket, ok} ->
                 void;
             {inet_reply, Socket, SendError} ->
@@ -871,3 +870,12 @@ udp_proc_loop(Socket, IP, Port, ParentPid) ->
     end,
     udp_proc_loop(Socket, IP, Port, ParentPid).
 
+
+-ifdef(bypass_gen_udp_send).
+udp_send(Socket, IP, Port, Pkt) ->
+    {IP1, IP2, IP3, IP4} = IP,
+    true = erlang:port_command(Socket, [?GEN_UDP_PORT_COMMAND_PREFIX, [((Port) bsr 8) band 16#ff, (Port) band 16#ff], [IP1 band 16#ff, IP2 band 16#ff, IP3 band 16#ff, IP4 band 16#ff], Pkt]).
+-else.
+udp_send(Socket, IP, Port, Pkt) ->
+    ok = gen_udp:send(Socket, IP, Port, Pkt).
+-endif.

--- a/uhal/uhal/src/common/ProtocolTCP.cpp
+++ b/uhal/uhal/src/common/ProtocolTCP.cpp
@@ -149,16 +149,8 @@ namespace uhal
   {
     log ( Info() , "Attempting to create TCP connection to '" , mEndpoint->host_name() , "' port " , mEndpoint->service_name() , "." );
     mDeadlineTimer.expires_from_now ( this->getBoostTimeoutPeriod() );
-    boost::system::error_code lErrorCode = boost::asio::error::would_block;
-    boost::asio::async_connect ( mSocket , mEndpoint , boost::lambda::var ( lErrorCode ) = boost::lambda::_1 );
-
-    // Unlock mutex whilst connect runs in other thread, to avoid deadlock in case timeout occurs
-    mTransportLayerMutex.unlock();
-    do
-    {
-    }
-    while ( lErrorCode == boost::asio::error::would_block );
-    mTransportLayerMutex.lock();
+    boost::system::error_code lErrorCode;
+    boost::asio::connect ( mSocket , mEndpoint , lErrorCode );
 
     if ( lErrorCode )
     {


### PR DESCRIPTION
This branch:
 * updates the Fedora 26 CI jobs to Fedora 30 (issue #152);
 * fixes a TCP connect infinite loop bug that occurs with boost 1.69/1.70 (issue #153); and
 * updates ControlHub to use plain `gen_udp:send` instead of `port_command` from Erlang 20