### PR TITLE
Make dummy hardware 'SetEndpoint' method non-private again

### DIFF
--- a/uhal/tests/include/uhal/tests/DummyHardware.hpp
+++ b/uhal/tests/include/uhal/tests/DummyHardware.hpp
@@ -113,9 +113,9 @@ namespace uhal
         */
         void AnalyzeReceivedAndCreateReply ( const uint32_t& aByteCount );
   
-      private:
-
         void SetEndpoint( const uint32_t& aAddress , const uint32_t&  aValue );
+
+      private:
 
         uint32_t GetEndpoint( const uint32_t& aAddress );
 


### PR DESCRIPTION
Fixes #149