### PR TITLE
Building on CentOS8

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -103,6 +103,13 @@ build:centos7:
     YUMGROUPS_FILE: "ci/yumgroups-centos7.xml"
     OUTPUT_REPO_SUBDIR: "centos7_x86_64"
 
+build:centos8:
+  <<: *build_rpm_yumrepo_jobTemplate
+  image: ${IPBUS_DOCKER_REGISTRY}/ipbus-sw-dev-centos8:2019-10-26__boost1.66.0_pugixml1.9
+  variables:
+    YUMGROUPS_FILE: "ci/yumgroups-centos7.xml"
+    OUTPUT_REPO_SUBDIR: "centos8_x86_64"
+
 
 
 .job_template: &simple_build_jobTemplate
@@ -182,6 +189,16 @@ publish_build_job:
     UHAL_ENABLE_IPBUS_PCIE: ""
     TEST_SUITE_CONTROLHUB_PATH_ARGUMENT: "-p /opt/cactus/bin"
     UHAL_GUI_DEPENDENCIES: "wxPython numpy"
+    VALGRIND_ARGS: "--suppressions=/opt/cactus/etc/uhal/tests/valgrind/uhal_tests.supp"
+
+.job_template: &centos8_test_jobTemplate
+  <<: *rpmInstall_test_jobTemplate
+  image: ${IPBUS_DOCKER_REGISTRY}/ipbus-sw-test-centos8:2019-10-26
+  variables:
+    REPO_URL_OS_SUBDIR: centos8_x86_64
+    UHAL_ENABLE_IPBUS_PCIE: ""
+    TEST_SUITE_CONTROLHUB_PATH_ARGUMENT: "-p /opt/cactus/bin"
+    UHAL_GUI_DEPENDENCIES: "python3-numpy"
     VALGRIND_ARGS: "--suppressions=/opt/cactus/etc/uhal/tests/valgrind/uhal_tests.supp"
 
 
@@ -321,6 +338,23 @@ test_tools:centos7:
 
 test_controlhub:centos7:
   <<: *centos7_test_jobTemplate
+  <<: *test_controlhub_plainScripts_jobTemplate
+
+
+test_core:centos8:
+  <<: *centos8_test_jobTemplate
+  <<: *test_core_jobTemplate
+
+test_python:centos8:
+  <<: *centos8_test_jobTemplate
+  <<: *test_python_jobTemplate
+
+test_tools:centos8:
+  <<: *centos8_test_jobTemplate
+  <<: *test_tools_jobTemplate
+
+test_controlhub:centos8:
+  <<: *centos8_test_jobTemplate
   <<: *test_controlhub_plainScripts_jobTemplate
 
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -168,7 +168,7 @@ publish_build_job:
     - sudo sed -i -re "s|^baseurl=.*|baseurl=${OUTPUT_PIPELINE_URL}/repos/${REPO_URL_OS_SUBDIR}|g" /etc/yum.repos.d/ipbus-sw-ci.repo
     - cat /etc/yum.repos.d/ipbus-sw-ci.repo
     - sudo rpm --rebuilddb && sudo yum clean all 
-    - sudo yum -y groupinstall ipbus-sw
+    - sudo yum -y groupinstall ${YUM_GROUPINSTALL_ARGUMENTS} ipbus-sw
     - sudo yum -y install 'cactuscore-uhal-*-debuginfo'
     - rpm -qa | grep cactus | sort
 
@@ -177,7 +177,6 @@ publish_build_job:
   image: ${IPBUS_DOCKER_REGISTRY}/ipbus-sw-test-slc6:2019-01-08
   variables:
     REPO_URL_OS_SUBDIR: slc6_x86_64
-    UHAL_ENABLE_IPBUS_PCIE: ""
     UHAL_GUI_DEPENDENCIES: "wxPython numpy"
     VALGRIND_ARGS: "--suppressions=/opt/cactus/etc/uhal/tests/valgrind/uhal_tests_slc6.supp"
 
@@ -186,7 +185,6 @@ publish_build_job:
   image: ${IPBUS_DOCKER_REGISTRY}/ipbus-sw-test-cc7:2019-01-08
   variables:
     REPO_URL_OS_SUBDIR: centos7_x86_64
-    UHAL_ENABLE_IPBUS_PCIE: ""
     TEST_SUITE_CONTROLHUB_PATH_ARGUMENT: "-p /opt/cactus/bin"
     UHAL_GUI_DEPENDENCIES: "wxPython numpy"
     VALGRIND_ARGS: "--suppressions=/opt/cactus/etc/uhal/tests/valgrind/uhal_tests.supp"
@@ -196,8 +194,8 @@ publish_build_job:
   image: ${IPBUS_DOCKER_REGISTRY}/ipbus-sw-test-centos8:2019-10-26
   variables:
     REPO_URL_OS_SUBDIR: centos8_x86_64
-    UHAL_ENABLE_IPBUS_PCIE: ""
     TEST_SUITE_CONTROLHUB_PATH_ARGUMENT: "-p /opt/cactus/bin"
+    YUM_GROUPINSTALL_ARGUMENTS: "--enablerepo=PowerTools"
     UHAL_GUI_DEPENDENCIES: "python3-numpy"
     VALGRIND_ARGS: "--suppressions=/opt/cactus/etc/uhal/tests/valgrind/uhal_tests.supp"
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -169,7 +169,7 @@ publish_build_job:
     - cat /etc/yum.repos.d/ipbus-sw-ci.repo
     - sudo rpm --rebuilddb && sudo yum clean all 
     - sudo yum -y groupinstall ${YUM_GROUPINSTALL_ARGUMENTS} ipbus-sw
-    - sudo yum -y install 'cactuscore-uhal-*-debuginfo'
+    - if [ "$REPO_URL_OS_SUBDIR" != "centos8_x86_64" ]; then sudo yum -y install 'cactuscore-uhal-*-debuginfo'; fi
     - rpm -qa | grep cactus | sort
 
 .job_template: &slc6_test_jobTemplate

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -105,7 +105,7 @@ build:centos7:
 
 build:centos8:
   <<: *build_rpm_yumrepo_jobTemplate
-  image: ${IPBUS_DOCKER_REGISTRY}/ipbus-sw-dev-centos8:2019-10-26__boost1.66.0_pugixml1.9
+  image: ${IPBUS_DOCKER_REGISTRY}/ipbus-sw-dev-centos8:2019-10-29__boost1.66.0_pugixml1.9
   variables:
     YUMGROUPS_FILE: "ci/yumgroups-centos7.xml"
     OUTPUT_REPO_SUBDIR: "centos8_x86_64"
@@ -191,7 +191,7 @@ publish_build_job:
 
 .job_template: &centos8_test_jobTemplate
   <<: *rpmInstall_test_jobTemplate
-  image: ${IPBUS_DOCKER_REGISTRY}/ipbus-sw-test-centos8:2019-10-26
+  image: ${IPBUS_DOCKER_REGISTRY}/ipbus-sw-test-centos8:2019-10-29
   variables:
     REPO_URL_OS_SUBDIR: centos8_x86_64
     TEST_SUITE_CONTROLHUB_PATH_ARGUMENT: "-p /opt/cactus/bin"

--- a/config/Makefile.macros
+++ b/config/Makefile.macros
@@ -18,6 +18,8 @@ ifeq ($(UNAME),Linux)
         CACTUS_OS=centos6
     else ifneq ($(findstring centos-7,$(CACTUS_PLATFORM)),)
         CACTUS_OS=centos7
+    else ifneq ($(findstring centos-8,$(CACTUS_PLATFORM)),)
+        CACTUS_OS=centos8
     endif
 else ifeq ($(UNAME),Darwin)
     CACTUS_OS=osx

--- a/controlhub/pkg/cactuscore-controlhub.spec.template
+++ b/controlhub/pkg/cactuscore-controlhub.spec.template
@@ -2,6 +2,8 @@
 # spec file for controlhub
 #
 
+%define _build_id_links none
+
 Name: %{name}
 Summary: IPbus packet-router
 Version: %{version}

--- a/uhal/config/mfPythonRPMRules.mk
+++ b/uhal/config/mfPythonRPMRules.mk
@@ -34,12 +34,16 @@ _rpmbuild: _setup_update
 	echo "include */*.so" > ${RPMBUILD_DIR}/MANIFEST.in
 	# Change into rpm/pkg to finally run the customized setup.py
 	if [ -f setup.cfg ]; then cp setup.cfg ${RPMBUILD_DIR}/ ; fi
-	echo '%debug_package %{nil}' >> ~/.rpmmacros
-	cd ${RPMBUILD_DIR} && bindir=$(bindir) python ${PackageName}.py bdist_rpm \
+	cd ${RPMBUILD_DIR} && python ${PackageName}.py bdist_rpm --spec-only \
 	  --release ${PACKAGE_RELEASE}.${CACTUS_OS}.${CXX_VERSION_TAG}.python${PYTHON_VERSION} \
 	  --requires "${VERSIONED_PYTHON_COMMAND} `find ${RPMBUILD_DIR} -type f -exec file {} \; | grep -v text | cut -d: -f1 | /usr/lib/rpm/find-requires | tr '\n' ' '`" \
-	  --binary-only --force-arch=`uname -m` 
-	sed -i '$ d' ~/.rpmmacros
+	  --binary-only --force-arch=`uname -m`
+	cd ${RPMBUILD_DIR} && bindir=$(bindir) python ${PackageName}.py sdist
+	mkdir -p ${RPMBUILD_DIR}/build/bdist.linux-x86_64/rpm/SOURCES
+	cp ${RPMBUILD_DIR}/dist/${PackageName}-*.tar.gz ${RPMBUILD_DIR}/build/bdist.linux-x86_64/rpm/SOURCES/
+	cd ${RPMBUILD_DIR} && bindir=$(bindir) rpmbuild -bb --define 'debug_package %{nil}' \
+	  --define '_topdir '${RPMBUILD_DIR}'/build/bdist.linux-x86_64/rpm' \
+	  --clean dist/${PackageName}.spec
 	# Harvest the crop
 	find ${RPMBUILD_DIR} -name "*.rpm" -exec mv {} ${PackagePath}/rpm \;
 
@@ -61,7 +65,7 @@ _setup_update:
 .PHONY: cleanrpm _cleanrpm
 cleanrpm: _cleanrpm
 _cleanrpm:
-	-rm -r rpm
+	rm -rf ${PackagePath}/rpm
 
 
 .PHONY: install

--- a/uhal/config/mfPythonRPMRules.mk
+++ b/uhal/config/mfPythonRPMRules.mk
@@ -16,7 +16,7 @@ include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/mfInstallVariables.mk
 
 RPMBUILD_DIR=${PackagePath}/rpm/RPMBUILD
 
-
+VERSIONED_PYTHON_COMMAND := $(shell python -c "from sys import version_info; print('python' + str(version_info[0]))")
 
 .PHONY: rpm _rpmall
 rpm: _rpmall
@@ -37,7 +37,7 @@ _rpmbuild: _setup_update
 	echo '%debug_package %{nil}' >> ~/.rpmmacros
 	cd ${RPMBUILD_DIR} && bindir=$(bindir) python ${PackageName}.py bdist_rpm \
 	  --release ${PACKAGE_RELEASE}.${CACTUS_OS}.${CXX_VERSION_TAG}.python${PYTHON_VERSION} \
-	  --requires "python `find ${RPMBUILD_DIR} -type f -exec file {} \; | grep -v text | cut -d: -f1 | /usr/lib/rpm/find-requires | tr '\n' ' '`" \
+	  --requires "${VERSIONED_PYTHON_COMMAND} `find ${RPMBUILD_DIR} -type f -exec file {} \; | grep -v text | cut -d: -f1 | /usr/lib/rpm/find-requires | tr '\n' ' '`" \
 	  --binary-only --force-arch=`uname -m` 
 	sed -i '$ d' ~/.rpmmacros
 	# Harvest the crop

--- a/uhal/config/mfPythonRPMRules.mk
+++ b/uhal/config/mfPythonRPMRules.mk
@@ -34,10 +34,12 @@ _rpmbuild: _setup_update
 	echo "include */*.so" > ${RPMBUILD_DIR}/MANIFEST.in
 	# Change into rpm/pkg to finally run the customized setup.py
 	if [ -f setup.cfg ]; then cp setup.cfg ${RPMBUILD_DIR}/ ; fi
+	echo '%debug_package %{nil}' >> ~/.rpmmacros
 	cd ${RPMBUILD_DIR} && bindir=$(bindir) python ${PackageName}.py bdist_rpm \
 	  --release ${PACKAGE_RELEASE}.${CACTUS_OS}.${CXX_VERSION_TAG}.python${PYTHON_VERSION} \
 	  --requires "python `find ${RPMBUILD_DIR} -type f -exec file {} \; | grep -v text | cut -d: -f1 | /usr/lib/rpm/find-requires | tr '\n' ' '`" \
-	  --binary-only --force-arch=`uname -m`
+	  --binary-only --force-arch=`uname -m` 
+	sed -i '$ d' ~/.rpmmacros
 	# Harvest the crop
 	find ${RPMBUILD_DIR} -name "*.rpm" -exec mv {} ${PackagePath}/rpm \;
 

--- a/uhal/config/specTemplate.spec
+++ b/uhal/config/specTemplate.spec
@@ -137,6 +137,15 @@ find ./ -type d -exec chmod 755 {} \;
 %{_prefix}/etc
 %{_prefix}/include
 
+# Temporary workaround for subpackages not being built on CentOS8
+%if %{defined _build_debuginfo_package}
+%if %{_os} == centos8
+/usr/lib/debug
+/usr/src/debug
+%endif
+%endif
+
+
 #
 # Files that go in the debuginfo RPM
 #

--- a/uhal/config/specTemplate.spec
+++ b/uhal/config/specTemplate.spec
@@ -12,10 +12,9 @@
 %define _author __author__
 %define _summary __summary__
 %define _url __url__
-#%define _buildarch __buildarch__
-#%define _includedirs __includedirs__
 
-#
+
+
 # SWATCH Specfile template
 # References: 
 # cmsos template file: https://svnweb.cern.ch/trac/cmsos/browser/trunk/config/spec.template
@@ -46,16 +45,19 @@ __description__
 # Devel RPM specified attributes (extension to binary rpm with include files)
 #
 %if %{defined _build_debuginfo_package}
-%package -n %{_packagename}-debuginfo
-Summary:  Debuginfo package for %{_summary}
+%package debuginfo
+Summary: Debuginfo package for %{_summary}
 
-%description -n %{_packagename}-debuginfo
+%description debuginfo
 __description__
 %endif
 
-#%prep
 
-#%build
+%prep
+
+
+%build
+
 
 %install 
 # copy files to RPM_BUILD_ROOT
@@ -114,12 +116,10 @@ cd %{_packagedir}
 #find src -name '*.cpp' -o -name '*.cxx' -fprintf rpm/debug.source "%p\0"
 #find src include -name '*.h' -print > rpm/debug.source -o -name '*.cc' -print > rpm/debug.source
 
-cat %{_packagedir}/rpm/debug.source | sort -z -u | egrep -v -z '(<internal>|<built-in>)$' | egrep -v -z %{_packagedir} >  %{_packagedir}/rpm/debug.source.clean
+cat %{_packagedir}/rpm/debug.source | sort -z -u | grep -E -v -z '(<internal>|<built-in>)$' | grep -E -v -z %{_packagedir} >  %{_packagedir}/rpm/debug.source.clean
 # Copy all sources and include files for debug RPMs
 cat  %{_packagedir}/rpm/debug.source.clean | ( cpio -pd0mL --quiet "$RPM_BUILD_ROOT/usr/src/debug/%{_packagename}-%{_version}" )
 
-#cat %{_packagedir}/rpm/debug.source | sort -z -u | egrep -v -z '(<internal>|<built-in>)$' | ( cpio -pd0mL --quiet "$RPM_BUILD_ROOT/usr/src/debug/%{_packagename}-%{_version}" )
-#cat %{_packagedir}/rpm/debug.include | sort -z -u | egrep -v -z '(<internal>|<built-in>)$' | ( cpio -pd0mL --quiet "$RPM_BUILD_ROOT/usr/src/debug/%{_packagename}-%{_version}" )
 # correct permissions on the created directories
 cd "$RPM_BUILD_ROOT/usr/src/debug/"
 find ./ -type d -exec chmod 755 {} \;
@@ -131,6 +131,7 @@ find ./ -type d -exec chmod 755 {} \;
 %post 
 
 %postun 
+
 
 %files 
 %defattr(-, root, root, -) 
@@ -147,12 +148,11 @@ find ./ -type d -exec chmod 755 {} \;
 %endif
 %endif
 
-
 #
 # Files that go in the debuginfo RPM
 #
 %if %{defined _build_debuginfo_package}
-%files -n %{_packagename}-debuginfo
+%files debuginfo
 %defattr(-,root,root,-)
 /usr/lib/debug
 /usr/src/debug

--- a/uhal/config/specTemplate.spec
+++ b/uhal/config/specTemplate.spec
@@ -76,12 +76,14 @@ fi
 if [ -d %{_packagedir}/bin ]; then
   cd %{_packagedir}/bin; \
 # find . -name "*" -exec install -D -m 755 {} $RPM_BUILD_ROOT/%{_prefix}/bin/{} \;
-  find . -name "*" -exec $BUILD_HOME/uhal/config/install.sh {} %{_prefix}/bin/%{_project}/{} 755 $RPM_BUILD_ROOT %{_packagedir} %{_packagename} %{_version} %{_prefix}/include '%{_includedirs}' \;
+  find . -type f -exec $BUILD_HOME/uhal/config/install.sh {} %{_prefix}/bin/%{_project}/{} 755 $RPM_BUILD_ROOT %{_packagedir} %{_packagename} %{_version} %{_prefix}/include '%{_includedirs}' \;
 fi
 
+%define versioned_python_command %(echo "$(python -c \"from sys import version_info; print('python' + str(version_info[0]))\")")
 if [ -d %{_packagedir}/scripts ]; then
   cd %{_packagedir}/scripts; \
-  find . -name ".svn" -prune -o -name "*" -exec install -D -m 755 {} $RPM_BUILD_ROOT/%{_prefix}/bin/%{_project}/{} \;
+  find . -type f -exec install -D -m 755 {} $RPM_BUILD_ROOT/%{_prefix}/bin/%{_project}/{} \;
+  find $RPM_BUILD_ROOT/%{_prefix}/bin/%{_project}/ -type f -exec sed -i "s|#!/usr/bin/env python|#!/usr/bin/env "%{versioned_python_command}"|" {} \;
 fi
 
 if [ -d %{_packagedir}/lib ]; then
@@ -100,7 +102,7 @@ fi
 
 if [ -d %{_packagedir}/etc ]; then
   cd %{_packagedir}/etc; \
-  find . -name ".svn" -prune -o -name "*" -exec install -D -m 644 {} $RPM_BUILD_ROOT/%{_prefix}/etc/{} \;
+  find . -type f -exec install -D -m 644 {} $RPM_BUILD_ROOT/%{_prefix}/etc/{} \;
 fi
 
 #cp -rp %{_sources_dir}/* $RPM_BUILD_ROOT%{_prefix}/.

--- a/uhal/gui/pkg/uhal/gui/guis/refresh_buttons_panel.py
+++ b/uhal/gui/pkg/uhal/gui/guis/refresh_buttons_panel.py
@@ -4,7 +4,7 @@ import wx
 class RefreshButtonsPanel(wx.Panel):
 
     def __init__(self, parent):
-        print "DEBUG: Refresh button panel instantiated"
+        print("DEBUG: Refresh button panel instantiated")
         wx.Panel.__init__(self, parent)
 
 
@@ -35,7 +35,7 @@ class RefreshButtonsPanel(wx.Panel):
         sizer.Fit(self)
 
     def __on_click_refresh(self, event):
-        print "DEBUG: Refresh button clicked. Calling default GUI"
+        print("DEBUG: Refresh button clicked. Calling default GUI")
         self.__parent.start_hw_thread()        
 
     '''

--- a/uhal/gui/pkg/uhal_gui.exe
+++ b/uhal/gui/pkg/uhal_gui.exe
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """
 usage: uhalgui.py [options] <guis python list>

--- a/uhal/pycohal/src/common/cactus_pycohal.cpp
+++ b/uhal/pycohal/src/common/cactus_pycohal.cpp
@@ -182,7 +182,7 @@ namespace pycohal
       try {
         bounds = aSlice.get_indicies<>(valVec.begin(), valVec.end());
       }
-      catch (std::invalid_argument) {
+      catch (const std::invalid_argument&) {
         return std::vector<T>();
       }
 

--- a/uhal/tests/scripts/ipbus2_udp_status.escript
+++ b/uhal/tests/scripts/ipbus2_udp_status.escript
@@ -1,4 +1,4 @@
-#!/bin/env escript
+#!/usr/bin/env escript
 
 % Basic Erlang script that sends IPbus 2.0 status request packet to a given target, and prints the response packet with nice formatting
 % Tom Williams, Nov 2013

--- a/uhal/tests/scripts/ipbus_perf_suite.py
+++ b/uhal/tests/scripts/ipbus_perf_suite.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 """
 Usage: ipbus_perf_suite.py <config file>
 

--- a/uhal/tests/scripts/test_pycohal
+++ b/uhal/tests/scripts/test_pycohal
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """
 Usage: test_pycohal -c <connections xml file> [-v] [other options for unittest module]

--- a/uhal/tests/scripts/uhal_test_suite.py
+++ b/uhal/tests/scripts/uhal_test_suite.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+
 """
 Usage: uhal_test_suite.py [-v] [-l] [-c <path to xml connections file>] [-s <search string for sections to run>]
 

--- a/uhal/tools/scripts/gen_ipbus_addr_decode
+++ b/uhal/tools/scripts/gen_ipbus_addr_decode
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/env python
+
 """
 usage: gen_ipus_addr_decode [options] <uhal_address_table.xml>
 

--- a/uhal/tools/scripts/uhal_inspect_registers.py
+++ b/uhal/tools/scripts/uhal_inspect_registers.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 
 """
 This script prints the values in a remote device, of registers below a specified uHAL node.


### PR DESCRIPTION
This branch:
 * Updates the makefiles to support building RPMs on CentOS8
   * Notably, the uHAL debuginfo packages are currently not built for CentOS8, as I did not identify any way to force the CentOS8 version of `rpmbuild` to create them (see e.g. https://bugzilla.redhat.com/show_bug.cgi?id=1756259). Instead, the debuginfo files are included in the 'main' RPMs
 * Updates the shebangs in various scripts to be compliant with CentOS8 packaging requirements/standards
 * Cleans up some parts of the RPM `.spec` files
 * Adds CentOS8 build and test jobs to the CI config; and
 * Updates uHAL source code in a couple of places to resolve warnings with newer versions of gcc / Python 3