### PR TITLE
Improve error checking for address table node attributes

### DIFF
--- a/uhal/log/include/uhal/log/exception.hpp
+++ b/uhal/log/include/uhal/log/exception.hpp
@@ -50,6 +50,7 @@
  class ClassName : public BaseClassName {\
  public:\
  ClassName() : BaseClassName() {}\
+ ClassName(const std::string& aMessage) : BaseClassName() {append(aMessage.c_str());}\
  void ThrowAsDerivedType_(){ throw ClassName(*this); } \
  exception* clone(){ return new ClassName(*this); } \
  protected:\

--- a/uhal/tests/src/common/test_nodes.cpp
+++ b/uhal/tests/src/common/test_nodes.cpp
@@ -609,6 +609,7 @@ BOOST_FIXTURE_TEST_CASE (invalid_mask, SimpleAddressTableFixture)
   lBadValues.push_back(" ");
   lBadValues.push_back("   ");
   lBadValues.push_back("-1");
+  lBadValues.push_back("42a");
   lBadValues.push_back("-0x11");
   lBadValues.push_back("0x");
   lBadValues.push_back("x");
@@ -640,6 +641,7 @@ BOOST_FIXTURE_TEST_CASE (invalid_size, SimpleAddressTableFixture)
   lBadValues.push_back(" ");
   lBadValues.push_back("   ");
   lBadValues.push_back("-1");
+  lBadValues.push_back("42a");
   lBadValues.push_back("-0x11");
   lBadValues.push_back("0x");
   lBadValues.push_back("x");

--- a/uhal/tests/src/common/test_nodes.cpp
+++ b/uhal/tests/src/common/test_nodes.cpp
@@ -486,7 +486,7 @@ void checkIteration(const uhal::Node& aNode, const NodeProperties& aProperties)
 }
 
 
-void checkNodeTree(const uhal::Node& aNode, const std::vector<NodeProperties>& aExpectedProperties, const bool aUseClient = true)
+void checkNodeTree(const uhal::Node& aNode, const std::vector<NodeProperties>& aExpectedProperties)
 {
   for (std::vector<NodeProperties>::const_iterator lIt = aExpectedProperties.begin(); lIt != aExpectedProperties.end(); lIt++) {
     BOOST_TEST_MESSAGE("Node '" << lIt->path << "'");
@@ -530,7 +530,7 @@ BOOST_AUTO_TEST_SUITE( simple )
 BOOST_FIXTURE_TEST_CASE (valid_default, SimpleAddressTableFixture)
 {
   boost::shared_ptr<Node> lNode(NodeTreeBuilder::getInstance().build(addrTableDoc.child ( "node" ), boost::filesystem::path()));
-  checkNodeTree(*lNode, nodeProperties, false);
+  checkNodeTree(*lNode, nodeProperties);
 }
 
 BOOST_FIXTURE_TEST_CASE (missing_ID, SimpleAddressTableFixture)

--- a/uhal/tests/src/common/test_nodes.cpp
+++ b/uhal/tests/src/common/test_nodes.cpp
@@ -29,6 +29,7 @@
 #include <typeinfo>
 
 #include "uhal/NodeTreeBuilder.hpp"
+#include "uhal/utilities/xml.hpp"
 #include "uhal/uhal.hpp"
 
 #include "uhal/tests/DummyDerivedNode.hpp"
@@ -532,7 +533,125 @@ BOOST_FIXTURE_TEST_CASE (valid_default, SimpleAddressTableFixture)
   checkNodeTree(*lNode, nodeProperties, false);
 }
 
-BOOST_FIXTURE_TEST_CASE (simple_reg_badpermission, SimpleAddressTableFixture)
+BOOST_FIXTURE_TEST_CASE (invalid_ID, SimpleAddressTableFixture)
+{
+  std::vector<std::string> lBadValues;
+  lBadValues.push_back("");
+  lBadValues.push_back(" ");
+  lBadValues.push_back("   ");
+  lBadValues.push_back(".");
+  lBadValues.push_back("bob.");
+  lBadValues.push_back(".bob");
+  lBadValues.push_back("some.value");
+
+  for (std::vector<std::string>::const_iterator lIt = lBadValues.begin(); lIt != lBadValues.end(); lIt++)
+  {
+    for (size_t i = 0; i < nodeProperties.size(); i++) {
+      BOOST_TEST_MESSAGE("Setting 'id' attribute of node " << i << " to '" << *lIt << "'");
+
+      pugi::xml_document lDoc;
+      lDoc.load(addrTableStr.c_str());
+      setAttribute(getNthChild(lDoc.child("node"), i), "id", *lIt);
+
+      BOOST_CHECK_THROW(NodeTreeBuilder::getInstance().build(lDoc.child ( "node" ), boost::filesystem::path()), exception::NodeAttributeIncorrectValue);
+    }
+  }
+}
+
+BOOST_FIXTURE_TEST_CASE (invalid_address, SimpleAddressTableFixture)
+{
+  std::vector<std::string> lBadValues;
+  lBadValues.push_back("");
+  lBadValues.push_back(" ");
+  lBadValues.push_back("   ");
+  lBadValues.push_back("-1");
+  lBadValues.push_back("-0x11");
+  lBadValues.push_back("0x");
+  lBadValues.push_back("x");
+  lBadValues.push_back("3.14");
+  lBadValues.push_back("bob");
+  lBadValues.push_back("0x1234bob5678");
+
+  // lBadValues.push_back("0x100000000");
+  // lBadValues.push_back("0x1FFF1234abcd");
+
+  for (std::vector<std::string>::const_iterator lIt = lBadValues.begin(); lIt != lBadValues.end(); lIt++)
+  {
+    for (size_t i = 0; i < nodeProperties.size(); i++) {
+      BOOST_TEST_MESSAGE("Setting 'address' attribute of node " << i << " to '" << *lIt << "'");
+
+      pugi::xml_document lDoc;
+      lDoc.load(addrTableStr.c_str());
+      setAttribute(getNthChild(lDoc.child("node"), i), "address", *lIt);
+
+      BOOST_CHECK_THROW(NodeTreeBuilder::getInstance().build(lDoc.child ( "node" ), boost::filesystem::path()), exception::NodeAttributeIncorrectValue);
+    }
+  }
+}
+
+BOOST_FIXTURE_TEST_CASE (invalid_mask, SimpleAddressTableFixture)
+{
+  std::vector<std::string> lBadValues;
+  lBadValues.push_back("");
+  lBadValues.push_back(" ");
+  lBadValues.push_back("   ");
+  lBadValues.push_back("-1");
+  lBadValues.push_back("-0x11");
+  lBadValues.push_back("0x");
+  lBadValues.push_back("x");
+  lBadValues.push_back("3.14");
+  lBadValues.push_back("bob");
+  lBadValues.push_back("0x1234bob5678");
+
+  // lBadValues.push_back("0x100000000");
+  // lBadValues.push_back("0x1FFF1234abcd");
+
+  for (std::vector<std::string>::const_iterator lIt = lBadValues.begin(); lIt != lBadValues.end(); lIt++)
+  {
+    for (size_t i = 0; i < 2; i++) {
+      BOOST_TEST_MESSAGE("Setting 'mask' attribute of node " << i << " to '" << *lIt << "'");
+
+      pugi::xml_document lDoc;
+      lDoc.load(addrTableStr.c_str());
+      setAttribute(getNthChild(lDoc.child("node"), i), "mask", *lIt);
+
+      BOOST_CHECK_THROW(NodeTreeBuilder::getInstance().build(lDoc.child ( "node" ), boost::filesystem::path()), exception::NodeAttributeIncorrectValue);
+    }
+  }
+}
+
+BOOST_FIXTURE_TEST_CASE (invalid_size, SimpleAddressTableFixture)
+{
+  std::vector<std::string> lBadValues;
+  lBadValues.push_back("");
+  lBadValues.push_back(" ");
+  lBadValues.push_back("   ");
+  lBadValues.push_back("-1");
+  lBadValues.push_back("-0x11");
+  lBadValues.push_back("0x");
+  lBadValues.push_back("x");
+  lBadValues.push_back("3.14");
+  lBadValues.push_back("bob");
+  lBadValues.push_back("0x1234bob5678");
+
+  // lBadValues.push_back("0x100000000");
+  // lBadValues.push_back("0x1FFF1234abcd");
+
+  for (std::vector<std::string>::const_iterator lIt = lBadValues.begin(); lIt != lBadValues.end(); lIt++)
+  {
+    for (size_t i = 2; i < nodeProperties.size(); i++) {
+      BOOST_TEST_MESSAGE("Setting 'size' attribute of node " << i << " to '" << *lIt << "'");
+
+      pugi::xml_document lDoc;
+      lDoc.load(addrTableStr.c_str());
+      setAttribute(getNthChild(lDoc.child("node"), i), "size", *lIt);
+
+      BOOST_CHECK_THROW(NodeTreeBuilder::getInstance().build(lDoc.child ( "node" ), boost::filesystem::path()), exception::NodeAttributeIncorrectValue);
+    }
+  }
+}
+
+BOOST_FIXTURE_TEST_CASE (invalid_permission, SimpleAddressTableFixture)
 {
   std::vector<std::string> lBadValues;
   lBadValues.push_back("bob");
@@ -557,6 +676,36 @@ BOOST_FIXTURE_TEST_CASE (simple_reg_badpermission, SimpleAddressTableFixture)
       pugi::xml_document lDoc;
       lDoc.load(addrTableStr.c_str());
       setAttribute(getNthChild(lDoc.child("node"), i), "permission", *lIt);
+
+      BOOST_CHECK_THROW(NodeTreeBuilder::getInstance().build(lDoc.child ( "node" ), boost::filesystem::path()), exception::NodeAttributeIncorrectValue);
+    }
+  }
+}
+
+BOOST_FIXTURE_TEST_CASE (invalid_mode, SimpleAddressTableFixture)
+{
+  std::vector<std::string> lBadValues;
+  lBadValues.push_back("bob");
+  lBadValues.push_back("some_invalid_string");
+  lBadValues.push_back("");
+  lBadValues.push_back("SINGLE");
+  lBadValues.push_back("BLOCK");
+  lBadValues.push_back("INCREMENTAL");
+  lBadValues.push_back("INC");
+  lBadValues.push_back("PORT");
+  lBadValues.push_back("NON-INCREMENTAL");
+  lBadValues.push_back("NON-INC");
+
+  lBadValues.push_back("single ");
+
+  for (std::vector<std::string>::const_iterator lIt = lBadValues.begin(); lIt != lBadValues.end(); lIt++)
+  {
+    for (size_t i = 0; i < nodeProperties.size(); i++) {
+      BOOST_TEST_MESSAGE("Setting 'mode' attribute of node " << i << " to '" << *lIt << "'");
+
+      pugi::xml_document lDoc;
+      lDoc.load(addrTableStr.c_str());
+      setAttribute(getNthChild(lDoc.child("node"), i), "mode", *lIt);
 
       BOOST_CHECK_THROW(NodeTreeBuilder::getInstance().build(lDoc.child ( "node" ), boost::filesystem::path()), exception::NodeAttributeIncorrectValue);
     }

--- a/uhal/tests/src/common/test_nodes.cpp
+++ b/uhal/tests/src/common/test_nodes.cpp
@@ -533,6 +533,19 @@ BOOST_FIXTURE_TEST_CASE (valid_default, SimpleAddressTableFixture)
   checkNodeTree(*lNode, nodeProperties, false);
 }
 
+BOOST_FIXTURE_TEST_CASE (missing_ID, SimpleAddressTableFixture)
+{
+  for (size_t i = 0; i < nodeProperties.size(); i++) {
+    BOOST_TEST_MESSAGE("Removing 'id' attribute from node " << i);
+
+    pugi::xml_document lDoc;
+    lDoc.load(addrTableStr.c_str());
+    getNthChild(lDoc.child("node"), i).remove_attribute("id");
+
+    BOOST_CHECK_THROW(NodeTreeBuilder::getInstance().build(lDoc.child ( "node" ), boost::filesystem::path()), exception::NoRulesPassed);
+  }
+}
+
 BOOST_FIXTURE_TEST_CASE (invalid_ID, SimpleAddressTableFixture)
 {
   std::vector<std::string> lBadValues;

--- a/uhal/uhal/include/uhal/NodeTreeBuilder.hpp
+++ b/uhal/uhal/include/uhal/NodeTreeBuilder.hpp
@@ -122,6 +122,8 @@ namespace uhal
       //! Clears address filename -> Node tree cache. NOT thread safe; for tread-safety, use ConnectionManager method
       void clearAddressFileCache();
 
+      Node* build(const pugi::xml_node& aNode, const boost::filesystem::path& aAddressFilePath);
+
     private:
       /**
       	Method called once the file specified in the call to getNodeTree( aFilenameExpr ) has been opened
@@ -131,7 +133,6 @@ namespace uhal
       	@param aAddressTable The address table constructed from the file
       */
       void CallBack ( const std::string& aProtocol , const boost::filesystem::path& aPath , std::vector<uint8_t>& aFile , std::vector< const Node* >& aAddressTable );
-
 
       /**
       	Propagate the addresses down through the hierarchical structure

--- a/uhal/uhal/include/uhal/NodeTreeBuilder.hpp
+++ b/uhal/uhal/include/uhal/NodeTreeBuilder.hpp
@@ -82,6 +82,9 @@ namespace uhal
 
     //! Exception class to handle the case when someone tries to give a bit-masked node a child.
     UHAL_DEFINE_EXCEPTION_CLASS ( MaskedNodeCannotHaveChild , "Exception class to handle the case when someone tries to give a bit-masked node a child." )
+
+    //! Exception class to handle the case when a node attribute has the incorrect value.
+    UHAL_DEFINE_EXCEPTION_CLASS ( NodeAttributeIncorrectValue , "Exception class to handle the case when a node attribute has the incorrect value." )
   }
 
 

--- a/uhal/uhal/include/uhal/NodeTreeBuilder.hpp
+++ b/uhal/uhal/include/uhal/NodeTreeBuilder.hpp
@@ -160,18 +160,18 @@ namespace uhal
       void setFirmwareInfo ( const pugi::xml_node& aXmlNode , Node* aNode );
       void addChildren ( const pugi::xml_node& aXmlNode , Node* aNode );
 
-      static const char* mIdAttribute;
-      static const char* mAddressAttribute;
-      static const char* mParametersAttribute;
-      static const char* mTagsAttribute;
-      static const char* mDescriptionAttribute;
-      static const char* mPermissionsAttribute;
-      static const char* mMaskAttribute;
-      static const char* mModeAttribute;
-      static const char* mSizeAttribute;
-      static const char* mClassAttribute;
-      static const char* mModuleAttribute;
-      static const char* mFirmwareInfo;
+      static const std::string mIdAttribute;
+      static const std::string mAddressAttribute;
+      static const std::string mParametersAttribute;
+      static const std::string mTagsAttribute;
+      static const std::string mDescriptionAttribute;
+      static const std::string mPermissionsAttribute;
+      static const std::string mMaskAttribute;
+      static const std::string mModeAttribute;
+      static const std::string mSizeAttribute;
+      static const std::string mClassAttribute;
+      static const std::string mModuleAttribute;
+      static const std::string mFirmwareInfo;
 
       Parser< Node* > mTopLevelNodeParser;
       Parser< Node* > mNodeParser;

--- a/uhal/uhal/include/uhal/NodeTreeBuilder.hpp
+++ b/uhal/uhal/include/uhal/NodeTreeBuilder.hpp
@@ -82,9 +82,6 @@ namespace uhal
 
     //! Exception class to handle the case when someone tries to give a bit-masked node a child.
     UHAL_DEFINE_EXCEPTION_CLASS ( MaskedNodeCannotHaveChild , "Exception class to handle the case when someone tries to give a bit-masked node a child." )
-
-    //! Exception class to handle the case when a node attribute has the incorrect value.
-    UHAL_DEFINE_EXCEPTION_CLASS ( NodeAttributeIncorrectValue , "Exception class to handle the case when a node attribute has the incorrect value." )
   }
 
 

--- a/uhal/uhal/include/uhal/XmlParser.hpp
+++ b/uhal/uhal/include/uhal/XmlParser.hpp
@@ -234,7 +234,7 @@ namespace uhal
       */
       R operator() ( const pugi::xml_node& aNode );
 
-      private:
+    private:
       //! One-hot encoded hash for rules
       uint64_t mNextHash;
       //! Map of the tags to the one-hot encoded hash
@@ -243,7 +243,6 @@ namespace uhal
       std::deque< Rule<R> > mRules;
       //! Member to track rule numbers for giving each rule a unique ID
       uint32_t mRuleCounter;
-
   };
 
 }

--- a/uhal/uhal/include/uhal/utilities/xml.hpp
+++ b/uhal/uhal/include/uhal/utilities/xml.hpp
@@ -61,6 +61,9 @@ namespace uhal
   {
     //! Exception class to handle the case where the string will not fit into a 32-bit number.
     UHAL_DEFINE_EXCEPTION_CLASS ( StringNumberWillNotFitInto32BitNumber , "Exception class to handle the case where the string will not fit into a 32-bit number." )
+
+    //! Exception class to handle the case when a node attribute has the incorrect value.
+    UHAL_DEFINE_EXCEPTION_CLASS ( NodeAttributeIncorrectValue , "Exception class to handle the case when a node attribute has the incorrect value." )
   }
 
   namespace utilities
@@ -82,7 +85,7 @@ namespace uhal
       @return success/failure status
     */
     template < bool DebugInfo >
-    bool GetXMLattribute ( const pugi::xml_node& aNode , const char* aAttrName , std::string& aTarget );
+    bool GetXMLattribute ( const pugi::xml_node& aNode , const std::string& aAttrName , std::string& aTarget );
 
 
     /**
@@ -93,7 +96,7 @@ namespace uhal
       @return success/failure status
     */
     template < bool DebugInfo >
-    bool GetXMLattribute ( const pugi::xml_node& aNode , const char* aAttrName , const char* aTarget );
+    bool GetXMLattribute ( const pugi::xml_node& aNode , const std::string& aAttrName , const char* aTarget );
 
 
     /**
@@ -104,7 +107,7 @@ namespace uhal
       @return success/failure status
     */
     template < bool DebugInfo >
-    bool GetXMLattribute ( const pugi::xml_node& aNode , const char* aAttrName , int32_t& aTarget );
+    bool GetXMLattribute ( const pugi::xml_node& aNode , const std::string& aAttrName , int32_t& aTarget );
 
 
     /**
@@ -115,7 +118,7 @@ namespace uhal
       @return success/failure status
     */
     template < bool DebugInfo >
-    bool GetXMLattribute ( const pugi::xml_node& aNode , const char* aAttrName , uint32_t& aTarget );
+    bool GetXMLattribute ( const pugi::xml_node& aNode , const std::string& aAttrName , uint32_t& aTarget );
 
 
     /**
@@ -126,7 +129,7 @@ namespace uhal
       @return success/failure status
     */
     template < bool DebugInfo >
-    bool GetXMLattribute ( const pugi::xml_node& aNode , const char* aAttrName , double& aTarget );
+    bool GetXMLattribute ( const pugi::xml_node& aNode , const std::string& aAttrName , double& aTarget );
 
 
     /**
@@ -137,7 +140,7 @@ namespace uhal
       @return success/failure status
     */
     template < bool DebugInfo >
-    bool GetXMLattribute ( const pugi::xml_node& aNode , const char* aAttrName , float& aTarget );
+    bool GetXMLattribute ( const pugi::xml_node& aNode , const std::string& aAttrName , float& aTarget );
 
 
     /**
@@ -148,7 +151,7 @@ namespace uhal
       @return success/failure status
     */
     template < bool DebugInfo >
-    bool GetXMLattribute ( const pugi::xml_node& aNode , const char* aAttrName , bool& aTarget );
+    bool GetXMLattribute ( const pugi::xml_node& aNode , const std::string& aAttrName , bool& aTarget );
 
   }
 }

--- a/uhal/uhal/src/common/NodeTreeBuilder.cpp
+++ b/uhal/uhal/src/common/NodeTreeBuilder.cpp
@@ -58,18 +58,18 @@ using boost::placeholders::_3;
 namespace uhal
 {
 
-  const char* NodeTreeBuilder::mIdAttribute = "id";
-  const char* NodeTreeBuilder::mAddressAttribute = "address";
-  const char* NodeTreeBuilder::mParametersAttribute = "parameters";
-  const char* NodeTreeBuilder::mTagsAttribute = "tags";
-  const char* NodeTreeBuilder::mDescriptionAttribute = "description";
-  const char* NodeTreeBuilder::mPermissionsAttribute = "permission";
-  const char* NodeTreeBuilder::mMaskAttribute = "mask";
-  const char* NodeTreeBuilder::mModeAttribute = "mode";
-  const char* NodeTreeBuilder::mSizeAttribute = "size";
-  const char* NodeTreeBuilder::mClassAttribute = "class";
-  const char* NodeTreeBuilder::mModuleAttribute = "module";
-  const char* NodeTreeBuilder::mFirmwareInfo = "fwinfo";
+  const std::string NodeTreeBuilder::mIdAttribute = "id";
+  const std::string NodeTreeBuilder::mAddressAttribute = "address";
+  const std::string NodeTreeBuilder::mParametersAttribute = "parameters";
+  const std::string NodeTreeBuilder::mTagsAttribute = "tags";
+  const std::string NodeTreeBuilder::mDescriptionAttribute = "description";
+  const std::string NodeTreeBuilder::mPermissionsAttribute = "permission";
+  const std::string NodeTreeBuilder::mMaskAttribute = "mask";
+  const std::string NodeTreeBuilder::mModeAttribute = "mode";
+  const std::string NodeTreeBuilder::mSizeAttribute = "size";
+  const std::string NodeTreeBuilder::mClassAttribute = "class";
+  const std::string NodeTreeBuilder::mModuleAttribute = "module";
+  const std::string NodeTreeBuilder::mFirmwareInfo = "fwinfo";
 
 
   boost::shared_ptr<NodeTreeBuilder> NodeTreeBuilder::mInstance;
@@ -345,7 +345,7 @@ namespace uhal
     if ( aRequireId and ( not lHasId ) )
     {
       //error description is given in the function itself so no more elaboration required
-      throw exception::NodeMustHaveUID();
+      throw exception::NodeMustHaveUID("'id' attribute is missing from address table node");
     }
 
     if ( lHasId )

--- a/uhal/uhal/src/common/NodeTreeBuilder.cpp
+++ b/uhal/uhal/src/common/NodeTreeBuilder.cpp
@@ -340,17 +340,22 @@ namespace uhal
 
   void NodeTreeBuilder::setUid ( const bool& aRequireId , const pugi::xml_node& aXmlNode , Node* aNode )
   {
-    if ( aRequireId )
+    const bool lHasId = uhal::utilities::GetXMLattribute<true> ( aXmlNode , NodeTreeBuilder::mIdAttribute , aNode->mUid );
+
+    if ( aRequireId and ( not lHasId ) )
     {
-      if ( ! uhal::utilities::GetXMLattribute<true> ( aXmlNode , NodeTreeBuilder::mIdAttribute , aNode->mUid ) )
-      {
-        //error description is given in the function itself so no more elaboration required
-        throw exception::NodeMustHaveUID();
-      }
+      //error description is given in the function itself so no more elaboration required
+      throw exception::NodeMustHaveUID();
     }
-    else
+
+    if ( lHasId )
     {
-      uhal::utilities::GetXMLattribute<false> ( aXmlNode , NodeTreeBuilder::mIdAttribute , aNode->mUid );
+      if ( aNode->mUid.empty() )
+        throw exception::NodeAttributeIncorrectValue("Invalid node ID specified (empty)");
+      else if ( aNode->mUid.find('.') != std::string::npos )
+        throw exception::NodeAttributeIncorrectValue("Invalid node ID '" + aNode->mUid + "' specified (contains dots)");
+      else if ( ( aNode->mUid.at(0) == ' ' ) or ( aNode->mUid.at(aNode->mUid.size()-1) == ' ' ) )
+        throw exception::NodeAttributeIncorrectValue("Invalid node ID '" + aNode->mUid + "' specified (contains spaces)");
     }
   }
 
@@ -447,7 +452,9 @@ namespace uhal
     {
       const defs::NodePermission* const lPermission = mPermissionsLut.find(lPermissionAttr.c_str());
       if (lPermission == NULL)
-        throw exception::NodeAttributeIncorrectValue();
+      {
+        throw exception::NodeAttributeIncorrectValue("Permission attribute for node with ID '" + aNode->mUid + "' has incorrect value '" + lPermissionAttr + "'");
+      }
       else
         aNode->mPermission = *lPermission;
     }
@@ -464,17 +471,17 @@ namespace uhal
   void NodeTreeBuilder::setModeAndSize ( const pugi::xml_node& aXmlNode , Node* aNode )
   {
     //Mode is an optional attribute for specifying whether a block is incremental, non-incremental or a single register
-    std::string lMode;
+    std::string lModeAttr;
 
-    if ( uhal::utilities::GetXMLattribute<false> ( aXmlNode , NodeTreeBuilder::mModeAttribute , lMode ) )
+    if ( uhal::utilities::GetXMLattribute<false> ( aXmlNode , NodeTreeBuilder::mModeAttribute , lModeAttr ) )
     {
-      boost::spirit::qi::phrase_parse (
-        lMode.begin(),
-        lMode.end(),
-        NodeTreeBuilder::mModeLut,
-        boost::spirit::ascii::space,
-        aNode->mMode
-      );
+      const defs::BlockReadWriteMode* const lMode = mModeLut.find(lModeAttr.c_str());
+      if (lMode == NULL)
+      {
+        throw exception::NodeAttributeIncorrectValue("Mode attribute for node with ID '" + aNode->mUid + "' has incorrect value '" + lModeAttr + "'");
+      }
+      else
+        aNode->mMode = *lMode;
 
       if ( aNode->mMode == defs::INCREMENTAL )
       {

--- a/uhal/uhal/src/common/utilities/xml.cpp
+++ b/uhal/uhal/src/common/utilities/xml.cpp
@@ -113,9 +113,9 @@ namespace uhal
 
 
     template < bool DebugInfo >
-    bool GetXMLattribute ( const pugi::xml_node& aNode , const char* aAttrName , std::string& aTarget )
+    bool GetXMLattribute ( const pugi::xml_node& aNode , const std::string& aAttrName , std::string& aTarget )
     {
-      pugi::xml_attribute lAttr = aNode.attribute ( aAttrName );
+      pugi::xml_attribute lAttr = aNode.attribute ( aAttrName.c_str() );
 
       if ( ! lAttr.empty() )
       {
@@ -133,14 +133,14 @@ namespace uhal
       }
     }
 
-    template bool GetXMLattribute<true>( const pugi::xml_node& aNode , const char* aAttrName , std::string& aTarget );
-    template bool GetXMLattribute<false>( const pugi::xml_node& aNode , const char* aAttrName , std::string& aTarget );
+    template bool GetXMLattribute<true>( const pugi::xml_node& aNode , const std::string& aAttrName , std::string& aTarget );
+    template bool GetXMLattribute<false>( const pugi::xml_node& aNode , const std::string& aAttrName , std::string& aTarget );
 
 
     template < bool DebugInfo >
-    bool GetXMLattribute ( const pugi::xml_node& aNode , const char* aAttrName , const char* aTarget )
+    bool GetXMLattribute ( const pugi::xml_node& aNode , const std::string& aAttrName , const char* aTarget )
     {
-      pugi::xml_attribute lAttr = aNode.attribute ( aAttrName );
+      pugi::xml_attribute lAttr = aNode.attribute ( aAttrName.c_str() );
 
       if ( ! lAttr.empty() )
       {
@@ -158,14 +158,14 @@ namespace uhal
       }
     }
 
-    template bool GetXMLattribute<true>( const pugi::xml_node& aNode , const char* aAttrName , const char* aTarget );
-    template bool GetXMLattribute<false>( const pugi::xml_node& aNode , const char* aAttrName , const char* aTarget );
+    template bool GetXMLattribute<true>( const pugi::xml_node& aNode , const std::string& aAttrName , const char* aTarget );
+    template bool GetXMLattribute<false>( const pugi::xml_node& aNode , const std::string& aAttrName , const char* aTarget );
 
 
     template < bool DebugInfo >
-    bool GetXMLattribute ( const pugi::xml_node& aNode , const char* aAttrName , int32_t& aTarget )
+    bool GetXMLattribute ( const pugi::xml_node& aNode , const std::string& aAttrName , int32_t& aTarget )
     {
-      pugi::xml_attribute lAttr = aNode.attribute ( aAttrName );
+      pugi::xml_attribute lAttr = aNode.attribute ( aAttrName.c_str() );
 
       if ( ! lAttr.empty() )
       {
@@ -234,47 +234,49 @@ namespace uhal
       }
     }
 
-    template bool GetXMLattribute<true>( const pugi::xml_node& aNode , const char* aAttrName , int32_t& aTarget );
-    template bool GetXMLattribute<false>( const pugi::xml_node& aNode , const char* aAttrName , int32_t& aTarget );
+    template bool GetXMLattribute<true>( const pugi::xml_node& aNode , const std::string& aAttrName , int32_t& aTarget );
+    template bool GetXMLattribute<false>( const pugi::xml_node& aNode , const std::string& aAttrName , int32_t& aTarget );
 
 
     template < bool DebugInfo >
-    bool GetXMLattribute ( const pugi::xml_node& aNode , const char* aAttrName , uint32_t& aTarget )
+    bool GetXMLattribute ( const pugi::xml_node& aNode , const std::string& aAttrName , uint32_t& aTarget )
     {
-      pugi::xml_attribute lAttr = aNode.attribute ( aAttrName );
+      pugi::xml_attribute lAttr = aNode.attribute ( aAttrName.c_str() );
 
       if ( ! lAttr.empty() )
       {
         std::string lAttrStr ( lAttr.value() );
         std::stringstream ss;
 
+        size_t lBasePrefixLength = 0;
+
+        if ( lAttrStr.empty() )
+          throw exception::NodeAttributeIncorrectValue("XML attribute '" + aAttrName + "' is empty, so cannot be converted to uint32_t");
+
         //if string is of the form "x89abcdef" , "X89abcdef" , "0x89abcdef" , "0X89abcdef"
         if ( lAttrStr.size() > 2 )
         {
-          if ( ( lAttrStr[1] == 'x' ) || ( lAttrStr[1] == 'X' ) )
+          if ( ( lAttrStr[0] == '0' ) and ( ( lAttrStr[1] == 'x' ) or ( lAttrStr[1] == 'X' ) ) )
           {
-            ss << std::hex << lAttrStr.substr ( 2 );
-          }
-          else
-          {
-            ss << lAttrStr;
+            lBasePrefixLength = 2;
+            ss << std::hex;
           }
         }
-        else if ( lAttrStr.size() > 1 )
+
+        if ( lAttrStr.size() > 1 )
         {
           if ( ( lAttrStr[0] == 'x' ) || ( lAttrStr[0] == 'X' ) )
           {
-            ss << std::hex << lAttrStr.substr ( 1 );
-          }
-          else
-          {
-            ss << lAttrStr;
+            lBasePrefixLength = 1;
+            ss << std::hex;
           }
         }
-        else
-        {
-          ss << lAttrStr;
-        }
+
+        if ( lAttrStr.find_first_not_of("0123456789", lBasePrefixLength) != std::string::npos )
+          throw exception::NodeAttributeIncorrectValue("XML attribute '" + aAttrName + "' has value '" + lAttrStr + "' that cannot be converted to uint32_t");
+
+        ss << lAttrStr.substr(lBasePrefixLength);
+        
 
         if ( ss.str().size() > 10 )
         {
@@ -307,14 +309,14 @@ namespace uhal
       }
     }
 
-    template bool GetXMLattribute<true>( const pugi::xml_node& aNode , const char* aAttrName , uint32_t& aTarget );
-    template bool GetXMLattribute<false>( const pugi::xml_node& aNode , const char* aAttrName , uint32_t& aTarget );
+    template bool GetXMLattribute<true>( const pugi::xml_node& aNode , const std::string& aAttrName , uint32_t& aTarget );
+    template bool GetXMLattribute<false>( const pugi::xml_node& aNode , const std::string& aAttrName , uint32_t& aTarget );
 
 
     template < bool DebugInfo >
-    bool GetXMLattribute ( const pugi::xml_node& aNode , const char* aAttrName , double& aTarget )
+    bool GetXMLattribute ( const pugi::xml_node& aNode , const std::string& aAttrName , double& aTarget )
     {
-      pugi::xml_attribute lAttr = aNode.attribute ( aAttrName );
+      pugi::xml_attribute lAttr = aNode.attribute ( aAttrName.c_str() );
 
       if ( ! lAttr.empty() )
       {
@@ -332,14 +334,14 @@ namespace uhal
       }
     }
 
-    template bool GetXMLattribute<true>( const pugi::xml_node& aNode , const char* aAttrName , double& aTarget );
-    template bool GetXMLattribute<false>( const pugi::xml_node& aNode , const char* aAttrName , double& aTarget );
+    template bool GetXMLattribute<true>( const pugi::xml_node& aNode , const std::string& aAttrName , double& aTarget );
+    template bool GetXMLattribute<false>( const pugi::xml_node& aNode , const std::string& aAttrName , double& aTarget );
 
 
     template < bool DebugInfo >
-    bool GetXMLattribute ( const pugi::xml_node& aNode , const char* aAttrName , float& aTarget )
+    bool GetXMLattribute ( const pugi::xml_node& aNode , const std::string& aAttrName , float& aTarget )
     {
-      pugi::xml_attribute lAttr = aNode.attribute ( aAttrName );
+      pugi::xml_attribute lAttr = aNode.attribute ( aAttrName.c_str() );
 
       if ( ! lAttr.empty() )
       {
@@ -357,14 +359,14 @@ namespace uhal
       }
     }
 
-    template bool GetXMLattribute<true>( const pugi::xml_node& aNode , const char* aAttrName , float& aTarget );
-    template bool GetXMLattribute<false>( const pugi::xml_node& aNode , const char* aAttrName , float& aTarget );
+    template bool GetXMLattribute<true>( const pugi::xml_node& aNode , const std::string& aAttrName , float& aTarget );
+    template bool GetXMLattribute<false>( const pugi::xml_node& aNode , const std::string& aAttrName , float& aTarget );
 
 
     template < bool DebugInfo >
-    bool GetXMLattribute ( const pugi::xml_node& aNode , const char* aAttrName , bool& aTarget )
+    bool GetXMLattribute ( const pugi::xml_node& aNode , const std::string& aAttrName , bool& aTarget )
     {
-      pugi::xml_attribute lAttr = aNode.attribute ( aAttrName );
+      pugi::xml_attribute lAttr = aNode.attribute ( aAttrName.c_str() );
 
       if ( ! lAttr.empty() )
       {
@@ -382,7 +384,7 @@ namespace uhal
       }
     }
 
-    template bool GetXMLattribute<true>( const pugi::xml_node& aNode , const char* aAttrName, bool& aTarget );
-    template bool GetXMLattribute<false>( const pugi::xml_node& aNode , const char* aAttrName, bool& aTarget );
+    template bool GetXMLattribute<true>( const pugi::xml_node& aNode , const std::string& aAttrName, bool& aTarget );
+    template bool GetXMLattribute<false>( const pugi::xml_node& aNode , const std::string& aAttrName, bool& aTarget );
   }
 }

--- a/uhal/uhal/src/common/utilities/xml.cpp
+++ b/uhal/uhal/src/common/utilities/xml.cpp
@@ -272,7 +272,7 @@ namespace uhal
           }
         }
 
-        if ( lAttrStr.find_first_not_of("0123456789", lBasePrefixLength) != std::string::npos )
+        if ( lAttrStr.find_first_not_of(lBasePrefixLength ? "0123456789abcdefABCDEF" : "0123456789", lBasePrefixLength) != std::string::npos )
           throw exception::NodeAttributeIncorrectValue("XML attribute '" + aAttrName + "' has value '" + lAttrStr + "' that cannot be converted to uint32_t");
 
         ss << lAttrStr.substr(lBasePrefixLength);


### PR DESCRIPTION
This branch updates the `NodeTreeBuilder` and XML utility functions to throw exceptions when erroneous values are specified for several node attributes - `id`, `mode`, `permission`, `address`, `mask` and `size`. As such it resolves issue #146 
