### PR TITLE
Fixing a missing reset of mAsynchronousException in PCIe::read()

### DIFF
--- a/uhal/uhal/src/common/ProtocolPCIe.cpp
+++ b/uhal/uhal/src/common/ProtocolPCIe.cpp
@@ -804,18 +804,14 @@ void PCIe::read()
   {
     if ( uhal::exception::exception* lExc = ClientInterface::validate ( lBuffers ) ) //Control of the pointer has been passed back to the client interface
     {
-      mAsynchronousException = lExc;
+      lExc->throwAsDerivedType();
     }
   }
   catch ( exception::exception& aExc )
   {
-    mAsynchronousException = new exception::ValidationError ();
-    log ( *mAsynchronousException , "Exception caught during reply validation for PCIe device with URI " , Quote ( this->uri() ) , "; what returned: " , Quote ( aExc.what() ) );
-  }
-
-  if ( mAsynchronousException )
-  {
-    mAsynchronousException->throwAsDerivedType();
+    exception::ValidationError lExc;
+    log ( lExc , "Exception caught during reply validation for PCIe device with URI " , Quote ( this->uri() ) , "; what returned: " , Quote ( aExc.what() ) );
+    throw lExc;
   }
 }
 

--- a/uhal/uhal/src/common/ProtocolPCIe.cpp
+++ b/uhal/uhal/src/common/ProtocolPCIe.cpp
@@ -799,6 +799,7 @@ void PCIe::read()
 
 
   // PART 3 : Validate the packet contents
+  mAsynchronousException = NULL;
   try
   {
     if ( uhal::exception::exception* lExc = ClientInterface::validate ( lBuffers ) ) //Control of the pointer has been passed back to the client interface


### PR DESCRIPTION
Fixing a missing reset of mAsynchronousException in PCIe::read(), which mistakenly stored the last exception encountered and kept failing on that one.

The output of the original test script used in the issue report (https://github.com/ipbus/ipbus-software/issues/187) now outputs:

```
$ python test_pcie_lockup_after_timeout.py
Before: reading node 'system_main.id.board_id' works just fine: 0x4454485f
17-03-20 16:59:13.244764 [7f1bc9d30740] WARNING - Expected reply packet to contain 3 words, but it actually contains 2 words
17-03-20 16:59:13.245643 [7f1bc9d30740] ERROR - Bad response code (0x = 'bus timeout on read') received for Incrementing read at base address 0x10000 (node "dth_tcds_top.user_main.dummy").  URI: "ipbuspcie-2.0:///dev/xdma0_h2c_0,/dev/xdma0_c2h_0". Sent/received headers: 0x2001010f / 0x20010006 (1/1 bytes into IPbus payload)
Now reading node 'user_main.dummy' does not work: Bad response code (0x = 'bus timeout on read') received for Incrementing read at base address 0x10000 (node "dth_tcds_top.user_main.dummy").  URI: "ipbuspcie-2.0:///dev/xdma0_h2c_0,/dev/xdma0_c2h_0". Sent/received headers: 0x2001010f / 0x20010006 (1/1 bytes into IPbus payload)
After: reading node 'system_main.id.board_id' still works: 4454485f
```