### PR TITLE
Adding missing bindings and converters

### DIFF
--- a/uhal/grammars/Makefile
+++ b/uhal/grammars/Makefile
@@ -10,7 +10,7 @@ PackageName = cactuscore-uhal-grammars
 
 PACKAGE_VER_MAJOR = 2
 PACKAGE_VER_MINOR = 7
-PACKAGE_VER_PATCH = 2
+PACKAGE_VER_PATCH = 3
 PACKAGE_RELEASE = 1${PACKAGE_RELEASE_SUFFIX}
 
 PackageSummary = uHAL Boost Spirit Grammars

--- a/uhal/gui/Makefile
+++ b/uhal/gui/Makefile
@@ -10,7 +10,7 @@ PackageName = cactuscore-uhal-gui
 
 PACKAGE_VER_MAJOR = 2
 PACKAGE_VER_MINOR = 7
-PACKAGE_VER_PATCH = 2
+PACKAGE_VER_PATCH = 3
 PACKAGE_RELEASE = 1${PACKAGE_RELEASE_SUFFIX}
 
 PackageDescription = Python GUI for uTCA HW access based on uHAL

--- a/uhal/log/Makefile
+++ b/uhal/log/Makefile
@@ -10,7 +10,7 @@ PackageName = cactuscore-uhal-log
 
 PACKAGE_VER_MAJOR = 2
 PACKAGE_VER_MINOR = 7
-PACKAGE_VER_PATCH = 2
+PACKAGE_VER_PATCH = 3
 PACKAGE_RELEASE = 1${PACKAGE_RELEASE_SUFFIX}
 
 PackageSummary = uHAL Logging Library

--- a/uhal/pycohal/Makefile
+++ b/uhal/pycohal/Makefile
@@ -10,7 +10,7 @@ PackageName = cactuscore-uhal-pycohal
 
 PACKAGE_VER_MAJOR = 2
 PACKAGE_VER_MINOR = 7
-PACKAGE_VER_PATCH = 2
+PACKAGE_VER_PATCH = 3
 PACKAGE_RELEASE = 1${PACKAGE_RELEASE_SUFFIX}
 
 PackageDescription = Python bindings for the uHAL library

--- a/uhal/pycohal/include/uhal/pycohal/converters.hpp
+++ b/uhal/pycohal/include/uhal/pycohal/converters.hpp
@@ -27,20 +27,6 @@ namespace pycohal {
     static void construct ( PyObject* obj_ptr, boost::python::converter::rvalue_from_python_stage1_data* data );
   };
 
-  struct Converter_vec_uint32_from_list {
-    // Default CTOR. Registers this converter to boost::python
-
-    Converter_vec_uint32_from_list() {
-      boost::python::converter::registry::push_back(&convertible, &construct, boost::python::type_id< std::vector<uint32_t> >());
-    }
-
-    // Determine if obj_ptr can be converted to vector<uint32_t>
-    static void* convertible(PyObject* obj_ptr);
-
-    // Convert obj_ptr to a C++ vector<uint32_t>
-    static void construct(PyObject* obj_ptr, boost::python::converter::rvalue_from_python_stage1_data* data);
-  };
-
   template <class T>
   struct Converter_std_vector_to_list {
     static PyObject* convert(const std::vector<T>& v);

--- a/uhal/pycohal/include/uhal/pycohal/converters.hpp
+++ b/uhal/pycohal/include/uhal/pycohal/converters.hpp
@@ -12,6 +12,21 @@
 
 namespace pycohal {
 
+
+  // CONVERTERS
+  template<class T>
+  struct Converter_std_vector_from_list {
+
+    // Default CTOR. Registers this converter to boost::python
+    Converter_std_vector_from_list();
+
+    // Determine if obj_ptr can be converted to vector<T>
+    static void* convertible ( PyObject* obj_ptr );
+
+    // Convert obj_ptr to a C++ vector<T>
+    static void construct ( PyObject* obj_ptr, boost::python::converter::rvalue_from_python_stage1_data* data );
+  };
+
   struct Converter_vec_uint32_from_list {
     // Default CTOR. Registers this converter to boost::python
 
@@ -76,5 +91,7 @@ PyObject* pycohal::Converter_boost_unorderedmap_to_dict<U,T>::convert(const boos
 
   return bpy::incref(theDict.ptr());
 }
+
+#include "uhal/pycohal/converters.hxx"
 
 #endif

--- a/uhal/pycohal/include/uhal/pycohal/converters.hxx
+++ b/uhal/pycohal/include/uhal/pycohal/converters.hxx
@@ -1,0 +1,54 @@
+#ifndef _uhal_pycohal_converters_hxx_
+#define _uhal_pycohal_converters_hxx_
+
+namespace pycohal {
+
+//------------------------------------------//
+// ---  Converter_std_vector_from_list  --- //
+//------------------------------------------//
+
+//---
+template<class T>
+Converter_std_vector_from_list<T>::Converter_std_vector_from_list() {
+    boost::python::converter::registry::push_back ( &convertible, &construct, boost::python::type_id< std::vector<T> >() );
+} 
+
+
+//---
+template <class T>
+void* 
+Converter_std_vector_from_list<T>::convertible ( PyObject* obj_ptr ) {
+  if ( !PyList_Check ( obj_ptr ) ) {
+    return 0;
+  } else {
+    return obj_ptr;
+  }
+}
+
+
+//---
+template <class T>
+void 
+Converter_std_vector_from_list<T>::construct ( PyObject* obj_ptr, boost::python::converter::rvalue_from_python_stage1_data* data ) {
+  namespace bpy = boost::python;
+  // Grab pointer to memory in which to construct the new vector
+  void* storage = ( ( bpy::converter::rvalue_from_python_storage< std::vector<T> >* ) data )->storage.bytes;
+  // Grab list object from obj_ptr
+  bpy::list py_list ( bpy::handle<> ( bpy::borrowed ( obj_ptr ) ) );
+  // Construct vector in requested location, and set element values.
+  // boost::python::extract will throw appropriate exception if can't convert to type T ; boost::python will then call delete itself as well.
+  size_t nItems = bpy::len ( py_list );
+  std::vector<T>* vec_ptr = new ( storage ) std::vector<T> ( nItems );
+
+  for ( size_t i = 0; i < nItems; i++ ) {
+    vec_ptr->at ( i ) = bpy::extract<T> ( py_list[i] );
+  }
+
+  // If successful, then register memory chunk pointer for later use by boost.python
+  data->convertible = storage;
+}
+
+}
+
+#endif /* _uhal_pycohal_converters_hxx_ */
+

--- a/uhal/pycohal/src/common/cactus_pycohal.cpp
+++ b/uhal/pycohal/src/common/cactus_pycohal.cpp
@@ -398,11 +398,13 @@ BOOST_PYTHON_MODULE ( _core )
   ;
   // Wrap uhal::ConnectionManager
   class_< uhal::ConnectionManager, boost::noncopyable > ( "ConnectionManager", init<const std::string&>() )
-  .def ( "getDevice",  static_cast< uhal::HwInterface ( uhal::ConnectionManager::* ) ( const std::string& ) > ( &uhal::ConnectionManager::getDevice ) )
+  .def ( init<const std::string&, const std::vector<std::string>&>() )
+  .def ( "getDevice", static_cast< uhal::HwInterface ( uhal::ConnectionManager::* ) ( const std::string& ) > ( &uhal::ConnectionManager::getDevice ) )
   .def ( "getDevices", static_cast< std::vector<std::string> ( uhal::ConnectionManager::* ) ()                   const > ( &uhal::ConnectionManager::getDevices ) )
   .def ( "getDevices", static_cast< std::vector<std::string> ( uhal::ConnectionManager::* ) ( const std::string& ) const > ( &uhal::ConnectionManager::getDevices ) )
   .def ( "clearAddressFileCache", &uhal::ConnectionManager::clearAddressFileCache )
   .staticmethod("clearAddressFileCache");
   def ( "getDevice", static_cast<uhal::HwInterface (* ) ( const std::string&, const std::string&, const std::string& ) > ( &uhal::ConnectionManager::getDevice ) );
+  def ( "getDevice", static_cast<uhal::HwInterface (* ) ( const std::string&, const std::string&, const std::string&, const std::vector<std::string>& ) > ( &uhal::ConnectionManager::getDevice ) );
 }
 

--- a/uhal/pycohal/src/common/converters.cpp
+++ b/uhal/pycohal/src/common/converters.cpp
@@ -10,12 +10,25 @@ namespace bpy = boost::python ;
 
 void pycohal::register_converters()
 {
-  pycohal::Converter_std_vector_from_list<uint32_t>();
-  pycohal::Converter_std_vector_from_list<std::string>();
-  bpy::to_python_converter< std::vector<std::string>, pycohal::Converter_std_vector_to_list<std::string> >();
-  bpy::to_python_converter< std::vector<uint32_t>, pycohal::Converter_std_vector_to_list<uint32_t> >();
-  bpy::to_python_converter< boost::unordered_map<std::string, std::string>, pycohal::Converter_boost_unorderedmap_to_dict<std::string,std::string> >(); 
+  const bpy::converter::registration* reg;
 
+  reg = bpy::converter::registry::query(bpy::type_id< std::vector<uint32_t> >());
+  if (reg == NULL or (*reg).m_to_python == NULL)
+  {
+    pycohal::Converter_std_vector_from_list<uint32_t>();
+    bpy::to_python_converter< std::vector<uint32_t>, pycohal::Converter_std_vector_to_list<uint32_t> >();
+  }
+
+  reg = bpy::converter::registry::query(bpy::type_id< std::vector<std::string> >());
+  if (reg == NULL or (*reg).m_to_python == NULL)
+  {
+    pycohal::Converter_std_vector_from_list<std::string>();
+    bpy::to_python_converter< std::vector<std::string>, pycohal::Converter_std_vector_to_list<std::string> >();
+  }
+
+  reg = bpy::converter::registry::query(bpy::type_id< boost::unordered_map<std::string, std::string> >());
+  if (reg == NULL or (*reg).m_to_python == NULL)
+    bpy::to_python_converter< boost::unordered_map<std::string, std::string>, pycohal::Converter_boost_unorderedmap_to_dict<std::string,std::string> >();
 }
 
 

--- a/uhal/pycohal/src/common/converters.cpp
+++ b/uhal/pycohal/src/common/converters.cpp
@@ -8,48 +8,9 @@
 
 namespace bpy = boost::python ;
 
-//-----------------------------------------//
-// ---  Converter_vec_uint32_from_list  ---//
-//-----------------------------------------//
-
-
-void* pycohal::Converter_vec_uint32_from_list::convertible ( PyObject* obj_ptr )
-{
-  if ( !PyList_Check ( obj_ptr ) )
-  {
-    return 0;
-  }
-  else
-  {
-    return obj_ptr;
-  }
-}
-
-
-void pycohal::Converter_vec_uint32_from_list::construct ( PyObject* obj_ptr, bpy::converter::rvalue_from_python_stage1_data* data )
-{
-  // Grab pointer to memory in which to construct the new vector
-  void* storage = ( ( bpy::converter::rvalue_from_python_storage< std::vector<uint32_t> >* ) data )->storage.bytes;
-  // Grab list object from obj_ptr
-  bpy::list py_list ( bpy::handle<> ( bpy::borrowed ( obj_ptr ) ) );
-  // Construct vector in requested location, and set element values.
-  // boost::python::extract will throw appropriate exception if can't convert to type T ; boost::python will then call delete itself as well.
-  size_t nItems = bpy::len ( py_list );
-  std::vector<uint32_t>* vec_ptr = new ( storage ) std::vector<uint32_t> ( nItems );
-
-  for ( size_t i=0; i<nItems; i++ )
-  {
-    vec_ptr->at ( i ) = bpy::extract<uint32_t> ( py_list[i] );
-  }
-
-  // If successful, then register memory chunk pointer for later use by boost.python
-  data->convertible = storage;
-}
-
-
 void pycohal::register_converters()
 {
-  pycohal::Converter_vec_uint32_from_list();
+  pycohal::Converter_std_vector_from_list<uint32_t>();
   pycohal::Converter_std_vector_from_list<std::string>();
   bpy::to_python_converter< std::vector<std::string>, pycohal::Converter_std_vector_to_list<std::string> >();
   bpy::to_python_converter< std::vector<uint32_t>, pycohal::Converter_std_vector_to_list<uint32_t> >();

--- a/uhal/pycohal/src/common/converters.cpp
+++ b/uhal/pycohal/src/common/converters.cpp
@@ -50,6 +50,7 @@ void pycohal::Converter_vec_uint32_from_list::construct ( PyObject* obj_ptr, bpy
 void pycohal::register_converters()
 {
   pycohal::Converter_vec_uint32_from_list();
+  pycohal::Converter_std_vector_from_list<std::string>();
   bpy::to_python_converter< std::vector<std::string>, pycohal::Converter_std_vector_to_list<std::string> >();
   bpy::to_python_converter< std::vector<uint32_t>, pycohal::Converter_std_vector_to_list<uint32_t> >();
   bpy::to_python_converter< boost::unordered_map<std::string, std::string>, pycohal::Converter_boost_unorderedmap_to_dict<std::string,std::string> >(); 

--- a/uhal/tests/Makefile
+++ b/uhal/tests/Makefile
@@ -10,7 +10,7 @@ PackageName = cactuscore-uhal-tests
 
 PACKAGE_VER_MAJOR = 2
 PACKAGE_VER_MINOR = 7
-PACKAGE_VER_PATCH = 2
+PACKAGE_VER_PATCH = 3
 PACKAGE_RELEASE = 1${PACKAGE_RELEASE_SUFFIX}
 
 PackageSummary = uHAL Library Tests

--- a/uhal/tests/etc/uhal/tests/dummy_level3_address.xml
+++ b/uhal/tests/etc/uhal/tests/dummy_level3_address.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 
-
 <node parameters="arg0=val300;arg1=val301;arg2=val302">
     <node id="REG" address="0x0001" permission="rw" tags="test"/>
 

--- a/uhal/tests/scripts/test_pycohal
+++ b/uhal/tests/scripts/test_pycohal
@@ -352,6 +352,57 @@ class TestValWordIntMethods(unittest.TestCase):
 #    Tests of normal use cases, involving actual interaction with (dummy) hardware
 #    (There is usually an equivalent C++ executable in uhal/tests.)
 
+
+class TestConnectionManager(unittest.TestCase):
+    """
+    TestCase sub-class checking that connection manager returns objects with correct attributes (incl. for user-defined clients).
+    """
+
+    def setUp(self):
+        self.manager = uhal.ConnectionManager(CONNECTIONS_FILE)
+
+    def check_hw_properties(self, hw, id, uri, clientType):
+        self.assertEqual(hw.id(),  id)
+        self.assertEqual(hw.uri(), uri)
+        self.assertEqual(hw.getClient().id(),  id)
+        self.assertEqual(hw.getClient().uri(), uri)
+        self.assertEqual(type(hw.getClient()), clientType)
+
+    def exe_test_getDevice_member(self, id, uri, clientType):
+        hw = self.manager.getDevice(id)
+        self.check_hw_properties(hw, id, uri, clientType)
+
+    def exe_test_getDevice_static(self, id, uri, clientType):
+        hw = uhal.getDevice(id, uri, ADDRESS_FILE)
+        self.check_hw_properties(hw, id, uri, clientType)
+
+    def test_getDevice_coreClients(self):
+        self.exe_test_getDevice_member('dummy.udp', 'ipbusudp-1.3://localhost:50001', uhal._core._UDP_IPbus_1_3)
+        self.exe_test_getDevice_member('dummy.udp2', 'ipbusudp-2.0://localhost:60001', uhal._core._UDP_IPbus_2_0)
+        self.exe_test_getDevice_member('dummy.tcp', 'ipbustcp-1.3://localhost:50002', uhal._core._TCP_IPbus_1_3)
+        self.exe_test_getDevice_member('dummy.tcp2', 'ipbustcp-2.0://localhost:60002', uhal._core._TCP_IPbus_2_0)
+        self.exe_test_getDevice_member('dummy.controlhub', 'chtcp-1.3://localhost:10203?target=localhost:50001', uhal._core._TCP_ControlHub_IPbus_1_3)
+        self.exe_test_getDevice_member('dummy.controlhub2', 'chtcp-2.0://localhost:10203?target=localhost:60001', uhal._core._TCP_ControlHub_IPbus_2_0)
+        self.exe_test_getDevice_member('dummy.pcie2', 'ipbuspcie-2.0:///tmp/uhal_pcie_client2device,/tmp/uhal_pcie_device2client', uhal.ClientInterface)
+
+        self.exe_test_getDevice_static('alice', 'ipbusudp-1.3://localhost:50001', uhal._core._UDP_IPbus_1_3)
+        self.exe_test_getDevice_static('bob', 'ipbusudp-2.0://localhost:50001', uhal._core._UDP_IPbus_2_0)
+        self.exe_test_getDevice_static('charlie', 'ipbustcp-1.3://localhost:50001', uhal._core._TCP_IPbus_1_3)
+        self.exe_test_getDevice_static('dave', 'ipbustcp-2.0://localhost:50001', uhal._core._TCP_IPbus_2_0)
+        self.exe_test_getDevice_static('x', 'chtcp-1.3://localhost:12345?target=localhost:50001', uhal._core._TCP_ControlHub_IPbus_1_3)
+        self.exe_test_getDevice_static('y', 'chtcp-2.0://localhost:12345?target=localhost:50001', uhal._core._TCP_ControlHub_IPbus_2_0)
+        self.exe_test_getDevice_static('z', 'ipbuspcie-2.0:///path1,/path2', uhal.ClientInterface)
+        self.exe_test_getDevice_static('z', 'ipbusmmap-2.0:///path/to/file', uhal.ClientInterface)
+
+        self.assertRaises(uhal.exception, uhal.getDevice, 'some_id', 'unknown_protocol://localhost:50001', ADDRESS_FILE)
+
+    def test_getDevice_userClients(self):
+        self.check_hw_properties(uhal.getDevice('bob', '__test__://localhost:50001', ADDRESS_FILE, ['__test__']), 'bob', '__test__://localhost:50001', uhal.ClientInterface)
+
+        self.assertRaises(uhal.exception, uhal.getDevice, 'bob', '__test__://localhost:50001', ADDRESS_FILE)
+        self.assertRaises(uhal.exception, uhal.getDevice, 'bob', '__test__://localhost:50001', ADDRESS_FILE, [])
+
+
 class TestSingle(unittest.TestCase):
     """
     TestCase sub-class checking write & read behaviour for a single register.

--- a/uhal/tools/Makefile
+++ b/uhal/tools/Makefile
@@ -10,7 +10,7 @@ PackageName = cactuscore-uhal-tools
 
 PACKAGE_VER_MAJOR = 2
 PACKAGE_VER_MINOR = 7
-PACKAGE_VER_PATCH = 2
+PACKAGE_VER_PATCH = 3
 PACKAGE_RELEASE = 1${PACKAGE_RELEASE_SUFFIX}
 
 PackageSummary = uTCA HW Development Tools that depend on uHAL

--- a/uhal/uhal/Makefile
+++ b/uhal/uhal/Makefile
@@ -10,7 +10,7 @@ PackageName = cactuscore-uhal-uhal
 
 PACKAGE_VER_MAJOR = 2
 PACKAGE_VER_MINOR = 7
-PACKAGE_VER_PATCH = 2
+PACKAGE_VER_PATCH = 3
 PACKAGE_RELEASE = 1${PACKAGE_RELEASE_SUFFIX}
 
 PackageSummary = uHAL Library


### PR DESCRIPTION
This pull requests extends to the python bindings to include the `ConnectionManager` functions (constructor, getDevice) enabling the use of external protocols.