### PR TITLE
Minor cleanup following up on pull request #188

### DIFF
--- a/uhal/uhal/include/uhal/ProtocolPCIe.hpp
+++ b/uhal/uhal/include/uhal/ProtocolPCIe.hpp
@@ -265,12 +265,6 @@ namespace uhal
 
       //! The list of buffers still awaiting a reply
       std::deque < boost::shared_ptr< Buffers > > mReplyQueue;
-
-      /**
-        A pointer to an exception object for passing exceptions from the worker thread to the main thread.
-        Exceptions must always be created on the heap (i.e. using `new`) and deletion will be handled in the main thread
-      */
-      uhal::exception::exception* mAsynchronousException;
   };
 
   std::ostream& operator<<(std::ostream& aStream, const PCIe::PacketFmt& aPacket);

--- a/uhal/uhal/src/common/ProtocolPCIe.cpp
+++ b/uhal/uhal/src/common/ProtocolPCIe.cpp
@@ -484,8 +484,7 @@ PCIe::PCIe ( const std::string& aId, const URI& aUri ) :
   mMaxPacketSize(0),
   mIndexNextPage(0),
   mPublishedReplyPageCount(0),
-  mReadReplyPageCount(0),
-  mAsynchronousException ( NULL )
+  mReadReplyPageCount(0)
 {
   if ( aUri.mHostname.find(",") == std::string::npos ) {
     exception::PCIeInitialisationError lExc;
@@ -799,20 +798,20 @@ void PCIe::read()
 
 
   // PART 3 : Validate the packet contents
-  mAsynchronousException = NULL;
+  uhal::exception::exception* lExc = NULL;
   try
   {
-    if ( uhal::exception::exception* lExc = ClientInterface::validate ( lBuffers ) ) //Control of the pointer has been passed back to the client interface
-    {
-      lExc->throwAsDerivedType();
-    }
+    lExc = ClientInterface::validate ( lBuffers );
   }
   catch ( exception::exception& aExc )
   {
-    exception::ValidationError lExc;
-    log ( lExc , "Exception caught during reply validation for PCIe device with URI " , Quote ( this->uri() ) , "; what returned: " , Quote ( aExc.what() ) );
-    throw lExc;
+    exception::ValidationError lExc2;
+    log ( lExc2 , "Exception caught during reply validation for PCIe device with URI " , Quote ( this->uri() ) , "; what returned: " , Quote ( aExc.what() ) );
+    throw lExc2;
   }
+
+  if (lExc != NULL)
+    lExc->throwAsDerivedType();
 }
 
 


### PR DESCRIPTION
This branch just removes a data member of the `PCIe` class that's now unused following the changes in pull request #188 , and performs a bit more cleanup of the area of code touched in that PR