### PR TITLE
Makefiles: Use variable for python command

### DIFF
--- a/config/Makefile.macros
+++ b/config/Makefile.macros
@@ -5,7 +5,8 @@ CACTUS_ROOT ?= /opt/cactus
 CACTUS_RPM_ROOT ?= $(BUILD_HOME)
 
 
-CACTUS_PLATFORM=$(shell python -c "import platform; print(platform.platform())")
+PYTHON ?= python
+CACTUS_PLATFORM=$(shell ${PYTHON} -c "import platform; print(platform.platform())")
 CACTUS_OS=unknown.os
 
 UNAME=$(strip $(shell uname -s))

--- a/uhal/Makefile
+++ b/uhal/Makefile
@@ -54,8 +54,9 @@ ${VIRTUAL_PACKAGES}:
 #     because removing installed files from one of the individual packages without removing any from other uhal packages
 #     would be much harder to implement (especially when coping with changes to filenames between different releases)
 
+PYTHON ?= python
 ifndef prefix
-  PYTHON_DIRECTORIES = $(shell python -c "import site,sys; print(' '.join([x+'/*uhal*' for x in site.getsitepackages()]))")
+  PYTHON_DIRECTORIES = $(shell ${PYTHON} -c "import site,sys; print(' '.join([x+'/*uhal*' for x in site.getsitepackages()]))")
 else
   PYTHON_DIRECTORIES = ${prefix}/lib/python*/*-packages/*uhal* ${exec_prefix}/lib/python*/*-packages/*uhal*
 endif

--- a/uhal/config/mfCommonDefs.mk
+++ b/uhal/config/mfCommonDefs.mk
@@ -22,9 +22,10 @@ endif
 MakeDir = mkdir -p
 
 
-PYTHON_VERSION ?= $(shell python -c "import distutils.sysconfig; print(distutils.sysconfig.get_python_version())")
-PYTHON_INCLUDE_PREFIX ?= $(shell python -c "import distutils.sysconfig; print(distutils.sysconfig.get_python_inc())")
-PYTHON_LIB_PREFIX ?= $(shell python -c "from distutils.sysconfig import get_python_lib; import os.path; print(os.path.split(get_python_lib(standard_lib=True))[0])")
+PYTHON ?= python
+PYTHON_VERSION ?= $(shell ${PYTHON} -c "import distutils.sysconfig; print(distutils.sysconfig.get_python_version())")
+PYTHON_INCLUDE_PREFIX ?= $(shell ${PYTHON} -c "import distutils.sysconfig; print(distutils.sysconfig.get_python_inc())")
+PYTHON_LIB_PREFIX ?= $(shell ${PYTHON} -c "from distutils.sysconfig import get_python_lib; import os.path; print(os.path.split(get_python_lib(standard_lib=True))[0])")
 
 # Construct C++ compiler suffix for RPM release field (tested with clang & gcc)
 CXX_VERSION_TAG = $(word 1, $(shell ${CXX} --version))

--- a/uhal/config/mfPythonRPMRules.mk
+++ b/uhal/config/mfPythonRPMRules.mk
@@ -10,7 +10,7 @@ PackageURL ?= None
 
 CACTUS_ROOT ?= /opt/cactus
 
-PYTHON_VERSIONED_COMMAND := $(shell python -c "from sys import version_info; print('python' + str(version_info[0]))")
+PYTHON_VERSIONED_COMMAND := $(shell ${PYTHON} -c "from sys import version_info; print('python' + str(version_info[0]))")
 BUILD_ARCH = $(shell rpm --eval "%{_target_cpu}")
 
 # By default, install Python bindings using same prefix & exec_prefix as main Python installation
@@ -40,13 +40,13 @@ _rpmbuild: _setup_update
 	# Change into rpm/pkg to finally run the customized setup.py
 	cd ${RPMBUILD_DIR} && \
 	  LIB_REQUIRES=$$(find ${RPMBUILD_DIR} -type f -print0 | xargs -0 -n1 -I {} file {} \; | grep -v text | cut -d: -f1 | /usr/lib/rpm/find-requires | tr '\n' ' ') && \
-	  python ${PackageName}.py bdist_rpm --spec-only \
+	  ${PYTHON} ${PackageName}.py bdist_rpm --spec-only \
 	    --release ${PACKAGE_RELEASE}.${CACTUS_OS}.python${PYTHON_VERSION} \
 	    --requires "${PYTHON_VERSIONED_COMMAND} $$LIB_REQUIRES" \
 	    --force-arch=${BUILD_ARCH} \
 	    --binary-only
 	cd ${RPMBUILD_DIR} && \
-	  bindir=$(bindir) python ${PackageName}.py sdist
+	  bindir=$(bindir) ${PYTHON} ${PackageName}.py sdist
 	mkdir -p ${RPMBUILD_DIR}/build/bdist.linux-${BUILD_ARCH}/rpm/SOURCES
 	cp ${RPMBUILD_DIR}/dist/${PackageName}-*.tar.gz ${RPMBUILD_DIR}/build/bdist.linux-${BUILD_ARCH}/rpm/SOURCES/
 	cd ${RPMBUILD_DIR} && \
@@ -89,4 +89,5 @@ install: _setup_update
 	echo "include */*.so" > ${RPMBUILD_DIR}/MANIFEST.in
 	# Change into rpm/pkg to finally run the customized setup.py
 	if [ -f setup.cfg ]; then cp setup.cfg ${RPMBUILD_DIR}/ ; fi
-	cd ${RPMBUILD_DIR} && bindir=$(bindir) python ${PackageName}.py install $(if ${CUSTOM_INSTALL_PREFIX},--prefix=${prefix},) $(if ${CUSTOM_INSTALL_PREFIX}${CUSTOM_INSTALL_EXEC_PREFIX},--exec-prefix=${exec_prefix},)
+	cd ${RPMBUILD_DIR} && \
+	  bindir=$(bindir) ${PYTHON} ${PackageName}.py install $(if ${CUSTOM_INSTALL_PREFIX},--prefix=${prefix},) $(if ${CUSTOM_INSTALL_PREFIX}${CUSTOM_INSTALL_EXEC_PREFIX},--exec-prefix=${exec_prefix},)

--- a/uhal/config/mfRPMRules.mk
+++ b/uhal/config/mfRPMRules.mk
@@ -10,6 +10,8 @@ REQUIRES_TAG = $(if ${PackageRequires} ,Requires: ${PackageRequires} ,\# No Requ
 
 RPM_RELEASE_SUFFIX = ${CACTUS_OS}$(if ${CXX_VERSION_TAG},.${CXX_VERSION_TAG},)
 
+PYTHON_VERSIONED_COMMAND := $(shell ${PYTHON} -c "from sys import version_info; print('python' + str(version_info[0]))")
+
 export BUILD_HOME
 
 .PHONY: rpm _rpmall
@@ -44,6 +46,7 @@ _spec_update:
 	       -e 's|^.*__build_requires__.*|${BUILD_REQUIRES_TAG}|' \
 	       -e 's|^.*__requires__.*|${REQUIRES_TAG}|' \
 	       -e 's|^BuildArch:.*|$(if ${PackageBuildArch},BuildArch: ${PackageBuildArch},\# BuildArch not specified)|' \
+	       -e 's#__python_versioned_command__#${PYTHON_VERSIONED_COMMAND}#' \
 	       ${PackagePath}/rpm/${PackageName}.spec
 	if [ "${BuildDebuginfoRPM}" == "1" ]; then sed -i '1 i\%define _build_debuginfo_package %{nil}' ${PackagePath}/rpm/${PackageName}.spec; fi
 

--- a/uhal/config/specTemplate.spec
+++ b/uhal/config/specTemplate.spec
@@ -11,6 +11,7 @@
 %define _author __author__
 %define _summary __summary__
 %define _url __url__
+%define _python_versioned_command __python_versioned_command__
 
 
 %define percent %( echo "%" )
@@ -80,10 +81,9 @@ if [ -d %{_packagedir}/bin ]; then
   find %{_packagedir}/bin -type f -printf '%{percent}P\0' | xargs -0 -n1 -I {} $BUILD_HOME/uhal/config/install.sh %{_packagedir}/bin/{} %{_prefix}/bin/%{_project}/{} 755 $RPM_BUILD_ROOT %{_packagedir} %{_packagename} %{_version} %{_prefix}/include '%{_includedirs}'
 fi
 
-%define versioned_python_command %(echo "$(python -c \"from sys import version_info; print('python' + str(version_info[0]))\")")
 if [ -d %{_packagedir}/scripts ]; then
   find %{_packagedir}/scripts -type f -printf '%{percent}P\0' | xargs -0 -n1 -I {} install -D -m 755 %{_packagedir}/scripts/{} $RPM_BUILD_ROOT/%{_prefix}/bin/%{_project}/{}
-  find $RPM_BUILD_ROOT/%{_prefix}/bin/%{_project} -type f -print0 | xargs -0 -n1 -I {} sed -i "s|#!/usr/bin/env python|#!/usr/bin/env "%{versioned_python_command}"|" {}
+  find $RPM_BUILD_ROOT/%{_prefix}/bin/%{_project} -type f -print0 | xargs -0 -n1 -I {} sed -i "s|#!/usr/bin/env python|#!/usr/bin/env "%{_python_versioned_command}"|" {}
 fi
 
 if [ -d %{_packagedir}/lib ]; then

--- a/uhal/grammars/Makefile
+++ b/uhal/grammars/Makefile
@@ -10,7 +10,7 @@ PackageName = cactuscore-uhal-grammars
 
 PACKAGE_VER_MAJOR = 2
 PACKAGE_VER_MINOR = 7
-PACKAGE_VER_PATCH = 5
+PACKAGE_VER_PATCH = 6
 PACKAGE_RELEASE = 1${PACKAGE_RELEASE_SUFFIX}
 
 PackageSummary = uHAL Boost Spirit Grammars

--- a/uhal/gui/Makefile
+++ b/uhal/gui/Makefile
@@ -10,7 +10,7 @@ PackageName = cactuscore-uhal-gui
 
 PACKAGE_VER_MAJOR = 2
 PACKAGE_VER_MINOR = 7
-PACKAGE_VER_PATCH = 5
+PACKAGE_VER_PATCH = 6
 PACKAGE_RELEASE = 1${PACKAGE_RELEASE_SUFFIX}
 
 PackageDescription = Python GUI for uTCA HW access based on uHAL

--- a/uhal/log/Makefile
+++ b/uhal/log/Makefile
@@ -10,7 +10,7 @@ PackageName = cactuscore-uhal-log
 
 PACKAGE_VER_MAJOR = 2
 PACKAGE_VER_MINOR = 7
-PACKAGE_VER_PATCH = 5
+PACKAGE_VER_PATCH = 6
 PACKAGE_RELEASE = 1${PACKAGE_RELEASE_SUFFIX}
 
 PackageSummary = uHAL Logging Library

--- a/uhal/pycohal/Makefile
+++ b/uhal/pycohal/Makefile
@@ -22,8 +22,8 @@ PackagerEmail = tom.williams@cern.ch
 PythonModules = ["uhal"]
 LibraryFile = pkg/uhal/_core.so
 
-PYTHON_VERSION_MAJOR_MINOR=$(shell python -c "import sys; print(str(sys.version_info.major)+str(sys.version_info.minor))")
-PYTHON_VERSION_MAJOR=$(shell python -c "import sys; print(sys.version_info.major)")
+PYTHON_VERSION_MAJOR_MINOR=$(shell ${PYTHON} -c "import sys; print(str(sys.version_info.major)+str(sys.version_info.minor))")
+PYTHON_VERSION_MAJOR=$(shell ${PYTHON} -c "import sys; print(sys.version_info.major)")
 ifeq (,$(shell ${CXX} -lboost_python${PYTHON_VERSION_MAJOR_MINOR} 2>&1 | grep -E 'ld: (cannot find|library not found)'))
   EXTERN_BOOST_PYTHON_LIB = boost_python${PYTHON_VERSION_MAJOR_MINOR}
 else ifeq (,$(shell ${CXX} -lboost_python${PYTHON_VERSION_MAJOR} 2>&1 | grep -E 'ld: (cannot find|library not found)'))

--- a/uhal/pycohal/Makefile
+++ b/uhal/pycohal/Makefile
@@ -10,7 +10,7 @@ PackageName = cactuscore-uhal-pycohal
 
 PACKAGE_VER_MAJOR = 2
 PACKAGE_VER_MINOR = 7
-PACKAGE_VER_PATCH = 5
+PACKAGE_VER_PATCH = 6
 PACKAGE_RELEASE = 1${PACKAGE_RELEASE_SUFFIX}
 
 PackageDescription = Python bindings for the uHAL library

--- a/uhal/tests/Makefile
+++ b/uhal/tests/Makefile
@@ -10,7 +10,7 @@ PackageName = cactuscore-uhal-tests
 
 PACKAGE_VER_MAJOR = 2
 PACKAGE_VER_MINOR = 7
-PACKAGE_VER_PATCH = 5
+PACKAGE_VER_PATCH = 6
 PACKAGE_RELEASE = 1${PACKAGE_RELEASE_SUFFIX}
 
 PackageSummary = uHAL Library Tests

--- a/uhal/tools/Makefile
+++ b/uhal/tools/Makefile
@@ -10,7 +10,7 @@ PackageName = cactuscore-uhal-tools
 
 PACKAGE_VER_MAJOR = 2
 PACKAGE_VER_MINOR = 7
-PACKAGE_VER_PATCH = 5
+PACKAGE_VER_PATCH = 6
 PACKAGE_RELEASE = 1${PACKAGE_RELEASE_SUFFIX}
 
 PackageSummary = uTCA HW Development Tools that depend on uHAL

--- a/uhal/tools/Makefile
+++ b/uhal/tools/Makefile
@@ -1,7 +1,7 @@
 BUILD_HOME = $(shell pwd)/../..
 
 include $(BUILD_HOME)/config/Makefile.macros
-include #(BUILD_HOME)/config/Makefile.macros
+include $(BUILD_HOME)/uhal/config/mfCommonDefs.mk
 
 Project = uhal/tools
 Package = uhal/tools

--- a/uhal/uhal/Makefile
+++ b/uhal/uhal/Makefile
@@ -10,7 +10,7 @@ PackageName = cactuscore-uhal-uhal
 
 PACKAGE_VER_MAJOR = 2
 PACKAGE_VER_MINOR = 7
-PACKAGE_VER_PATCH = 5
+PACKAGE_VER_PATCH = 6
 PACKAGE_RELEASE = 1${PACKAGE_RELEASE_SUFFIX}
 
 PackageSummary = uHAL Library


### PR DESCRIPTION
This branch updates the makefiles such that they use a variable (`PYTHON`) whenever invoking the Python command. This should make it slightly easier to build against specific Python installations as one can just override the `PYTHON` variable in the make command, e.g. `make PYTHON=/path/to/pythonXY` (prompted by a recent question in issue #163).