### PR TITLE
uHAL, Python: Shorten LD_LIBRARY_PATH-based import error messages

### DIFF
--- a/uhal/pycohal/pkg/uhal/__init__.py
+++ b/uhal/pycohal/pkg/uhal/__init__.py
@@ -4,7 +4,7 @@ import sys
 try:
     from ._core import *
 except ImportError as e:
-    message = 'Could not load uHAL Python bindings (typical cause: paths missing from LD_LIBRARY_PATH).'
+    message = 'Failed to load uHAL bindings.'
     message += '\nDetails: "{}"'
 
     if sys.version_info[0] > 2:

--- a/uhal/pycohal/pkg/uhal/__init__.py
+++ b/uhal/pycohal/pkg/uhal/__init__.py
@@ -8,7 +8,7 @@ except ImportError as e:
     message += '\nDetails: "{}"'
 
     if sys.version_info[0] > 2:
-        raise type(e)(message.format(e.msg)).with_traceback(sys.exc_info()[2])
+        exec('raise type(e)(message.format(e.msg)).with_traceback(sys.exc_info()[2]) from None')
     else:
         exec('raise type(e), message.format(e.message), sys.exc_info()[2]')
 

--- a/uhal/pycohal/pkg/uhal/__init__.py
+++ b/uhal/pycohal/pkg/uhal/__init__.py
@@ -2,18 +2,15 @@
 import sys
 
 try:
-   from ._core import *
+    from ._core import *
 except ImportError as e:
-    from os import environ
-    if ('LD_LIBRARY_PATH' not in environ) or '/opt/cactus/lib' not in environ['LD_LIBRARY_PATH'].split():
-        msg_suffix = '\nN.B. ImportError (or derived exception) raised when uHAL\'s __init__.py tries to load python bindings library\n     Maybe you need to add "/opt/cactus/lib", or some other path, to the "LD_LIBRARY_PATH" environment variable?'
-        if sys.version_info[0] > 2:
-            # raise type(e)(type(e)(new_msg)).with_traceback()
-            exec('raise type(e)(e.msg + msg_suffix) from e')
-        else:
-            exec('raise type(e), type(e)(e.message + msg_suffix), sys.exc_info()[2]')
+    message = 'Could not load uHAL Python bindings (typical cause: paths missing from LD_LIBRARY_PATH).'
+    message += '\nDetails: "{}"'
+
+    if sys.version_info[0] > 2:
+        raise type(e)(message.format(e.msg)).with_traceback(sys.exc_info()[2])
     else:
-        raise
+        exec('raise type(e), message.format(e.message), sys.exc_info()[2]')
 
 
 ##################################################

--- a/uhal/tools/scripts/gen_ipbus_addr_decode
+++ b/uhal/tools/scripts/gen_ipbus_addr_decode
@@ -19,7 +19,6 @@ import math
 import os.path
 import sys
 import time
-import uhal
 
 if sys.version_info[0] < 3:
     range = xrange
@@ -206,6 +205,7 @@ class nodetree(object):
 
 EXIT_CODE_ARG_PARSING_ERROR   = 1
 EXIT_CODE_NODE_ADDRESS_ERRORS = 2
+EXIT_CODE_IMPORT_ERROR        = 3
 
 def main():    
     logging.basicConfig(level=logging.WARNING, format='%(levelname)s\t: %(message)s')
@@ -213,6 +213,13 @@ def main():
     # configure logger
     global log
     log = logging.getLogger("main")
+
+    try:
+        import uhal
+    except ImportError as e:
+        print("Exception raised when importing uHAL ... ")
+        print(type(e).__name__ + ': ' + str(e))
+        sys.exit(EXIT_CODE_IMPORT_ERROR)
 
     uhal.setLogLevelTo(uhal.LogLevel.WARNING)
 

--- a/uhal/tools/scripts/gen_ipbus_addr_decode
+++ b/uhal/tools/scripts/gen_ipbus_addr_decode
@@ -217,8 +217,7 @@ def main():
     try:
         import uhal
     except ImportError as e:
-        print("Exception raised when importing uHAL ... ")
-        print(type(e).__name__ + ': ' + str(e))
+        print('ERROR: ' + str(e))
         sys.exit(EXIT_CODE_IMPORT_ERROR)
 
     uhal.setLogLevelTo(uhal.LogLevel.WARNING)


### PR DESCRIPTION
Fixes issue #213. 

Message of `ImportError` exception thrown from uhal `__init__.py` file is now:
```
Could not load uHAL Python bindings (typical cause: paths missing from LD_LIBRARY_PATH).
Details: "libcactus_uhal_tests.so.2.7: cannot open shared object file: No such file or directory"
```
(where the quoted string on the 2nd line is the message of the original exception from the `from ._core import *` statement.)

Full output of `gen_ipbus_addr_decode` if `LD_LIBRARY_PATH` not correctly set:
```
Exception raised when importing uHAL ... 
ImportError: Could not load uHAL Python bindings (typical cause: paths missing from LD_LIBRARY_PATH).
Details: "libcactus_uhal_tests.so.2.7: cannot open shared object file: No such file or directory"
```