### PR TITLE
Implement Python buffer protocol.

### DIFF
--- a/uhal/python/src/common/cactus_pycohal.cpp
+++ b/uhal/python/src/common/cactus_pycohal.cpp
@@ -260,7 +260,7 @@ PYBIND11_MODULE(_core, m)
     ;
 
   // Wrap uhal::ValVector<uint32_t>
-  py::class_<uhal::ValVector<uint32_t>>(m, "ValVector_uint32")
+  py::class_<uhal::ValVector<uint32_t>>(m, "ValVector_uint32", py::buffer_protocol())
     .def ( py::init<>() )
     .def ( py::init< const uhal::ValVector<uint32_t>& >() )
     .def ( "valid", static_cast< bool ( uhal::ValVector<uint32_t>::* ) () > ( &uhal::ValVector<uint32_t>::valid ) )
@@ -272,6 +272,13 @@ PYBIND11_MODULE(_core, m)
     .def ( "__getitem__", &pycohal::ValVectorIndexingSuite<uint32_t>::getItem , pycohal::const_ref_return_policy )
     .def ( "__getitem__", &pycohal::ValVectorIndexingSuite<uint32_t>::getSlice )
     .def ( "__iter__", [](const uhal::ValVector<uint32_t>& v) { return py::make_iterator ( v.begin() , v.end() ); })
+    .def_buffer([](const uhal::ValVector<uint32_t> &v) -> py::buffer_info {
+      return py::buffer_info(
+        v.data(),                    /* Pointer to buffer */
+        v.size(),                    /* Buffer size */
+        true                         /* Read-only */
+      );
+    })
     ;
 
   // Wrap uhal::Node

--- a/uhal/uhal/include/uhal/ValMem.hpp
+++ b/uhal/uhal/include/uhal/ValMem.hpp
@@ -358,7 +358,7 @@ namespace uhal
         Return the address of the underlying memory
         @return the address of the underlying memory
       */
-      T* data() const;
+      const T* data() const;
 
       //! Clear the underlying memory and set Validity to false
       void clear();

--- a/uhal/uhal/include/uhal/ValMem.hpp
+++ b/uhal/uhal/include/uhal/ValMem.hpp
@@ -354,6 +354,12 @@ namespace uhal
       */
       std::size_t size() const;
 
+      /**
+        Return the address of the underlying memory
+        @return the address of the underlying memory
+      */
+      T* data() const;
+
       //! Clear the underlying memory and set Validity to false
       void clear();
 

--- a/uhal/uhal/src/common/ValMem.cpp
+++ b/uhal/uhal/src/common/ValMem.cpp
@@ -284,6 +284,13 @@ namespace uhal
 
 
   template< typename T >
+  T* ValVector< T >::data() const
+  {
+    return mMembers->value.data();
+  }
+
+
+  template< typename T >
   void ValVector< T >::clear()
   {
     mMembers->valid = false;

--- a/uhal/uhal/src/common/ValMem.cpp
+++ b/uhal/uhal/src/common/ValMem.cpp
@@ -284,9 +284,18 @@ namespace uhal
 
 
   template< typename T >
-  T* ValVector< T >::data() const
+  const T* ValVector< T >::data() const
   {
-    return mMembers->value.data();
+    if ( mMembers->valid )
+    {
+      return mMembers->value.data();
+    }
+    else
+    {
+      exception::NonValidatedMemory lExc;
+      log ( lExc , "Access attempted on non-validated memory" );
+      throw lExc;
+    }
   }
 
 


### PR DESCRIPTION
Hello,

I am currently working on a piece of DAQ software that uses the Python `uhal` bindings. Performance is an issue, so I tried to get the data transfer into the Python environment as fast as possible.

For this, I implemented the "buffer protocol" which allows Python objects to access each others underlying memory. It makes e.g. conversions of the read out ValVectors into Numpy arrays much much faster.

I tried converting the ValVector directly `arr = np.array(valvector)` or via the `value` method `arr = np.array(valvector.value())`.

Without my patch:

```
Reading 1000 blocks with 32768 words each...
Time: 1.855031
With array conversion...
Time: 197.910151
With array value conversion...
Time: 7.071396
```

With my patch:

```
Reading 1000 blocks with 32768 words each...
Time: 1.896150
With array conversion...
Time: 1.882111
With array value conversion...
Time: 6.806115
```

As you can see, when the buffer protocol is implemented, a direct conversion to an array happens pretty much instantaneously, since the memory does not even have to be copied.

Please let me know what you think!