### PR TITLE
Adding rt to libraries in Makefile of `uhal/uhal`

### DIFF
--- a/uhal/uhal/Makefile
+++ b/uhal/uhal/Makefile
@@ -35,6 +35,7 @@ LibraryPaths = ${EXTERN_BOOST_LIB_PREFIX} \
 		${BUILD_HOME}/uhal/grammars/lib
 
 Libraries = pthread \
+		rt \
 		\
 		pugixml \
 		\


### PR DESCRIPTION
After an update of ubuntu to version v2.8v.0 and ipbusv2.8.0, we received the error

``` 
A dynamic linking error occurred: (/opt/cactus/lib/libcactus_uhal_uhal.so.2.8: undefined symbol: shm_open)
```

Adding `rt` to the list of libraries in `uhal/uhal/Makefile` solved it for us: 
![Screenshot from 2021-03-03 17-56-57](https://user-images.githubusercontent.com/17121295/109842451-63e04b80-7c4a-11eb-8ceb-ee41c533789a.png)

We are a little bit puzzled as, why this was not an issue on older ubuntu versions. 