### PR TITLE
Add version header

### DIFF
--- a/controlhub/Makefile
+++ b/controlhub/Makefile
@@ -32,7 +32,7 @@ Packager = Tom Williams
 
 PACKAGE_VER_MAJOR = 2
 PACKAGE_VER_MINOR = 8
-PACKAGE_VER_PATCH = 0
+PACKAGE_VER_PATCH = 1
 
 # This is the version number for the RPM packaging.
 PACKAGE_RELEASE = 1${PACKAGE_RELEASE_SUFFIX}

--- a/controlhub/ebin/controlhub.app
+++ b/controlhub/ebin/controlhub.app
@@ -10,7 +10,7 @@
 %%% ===========================================================================
 {application, controlhub,
  [{description, "Control Hub: multi-client packet routing for IPbus/UDP hardware"},
-   {vsn, "2.8.0"},
+   {vsn, "2.8.1"},
    {modules, [controlhub_app,
               ch_config,
               ch_sup,

--- a/controlhub/rel/reltool.config
+++ b/controlhub/rel/reltool.config
@@ -4,7 +4,7 @@
        {lib_dirs, []},
        {erts, [{mod_cond, derived}, {app_file, strip}]},
        {app_file, strip},
-       {rel, "controlhub", "2.8.0",
+       {rel, "controlhub", "2.8.1",
         [
          kernel,
          stdlib,

--- a/uhal/config/mfCommonDefs.mk
+++ b/uhal/config/mfCommonDefs.mk
@@ -15,7 +15,7 @@ ARFLAGS = rc
 ifdef BUILD_STATIC
   LDFLAGS = -static -Wl,-Bstatic -shared-libgcc -Wall -g -O3 -fPIC
 else
-  LDFLAGS = -Wall -g -O3 -fPIC
+  LDFLAGS = -Wall -g -O3 -fPIC -Wl,--no-as-needed -lrt
 endif
 
 # Tools

--- a/uhal/grammars/Makefile
+++ b/uhal/grammars/Makefile
@@ -10,7 +10,7 @@ PackageName = cactuscore-uhal-grammars
 
 PACKAGE_VER_MAJOR = 2
 PACKAGE_VER_MINOR = 8
-PACKAGE_VER_PATCH = 0
+PACKAGE_VER_PATCH = 1
 PACKAGE_RELEASE = 1${PACKAGE_RELEASE_SUFFIX}
 
 PackageSummary = uHAL Boost Spirit Grammars

--- a/uhal/gui/Makefile
+++ b/uhal/gui/Makefile
@@ -13,7 +13,7 @@ PackageName = cactuscore-uhal-python${PYTHON_VERSION_MAJOR_MINOR}-gui
 
 PACKAGE_VER_MAJOR = 2
 PACKAGE_VER_MINOR = 8
-PACKAGE_VER_PATCH = 0
+PACKAGE_VER_PATCH = 1
 PACKAGE_RELEASE = 1${PACKAGE_RELEASE_SUFFIX}
 
 PackageDescription = Python GUI for uTCA HW access based on uHAL

--- a/uhal/log/Makefile
+++ b/uhal/log/Makefile
@@ -10,7 +10,7 @@ PackageName = cactuscore-uhal-log
 
 PACKAGE_VER_MAJOR = 2
 PACKAGE_VER_MINOR = 8
-PACKAGE_VER_PATCH = 0
+PACKAGE_VER_PATCH = 1
 PACKAGE_RELEASE = 1${PACKAGE_RELEASE_SUFFIX}
 
 PackageSummary = uHAL Logging Library

--- a/uhal/python/Makefile
+++ b/uhal/python/Makefile
@@ -13,7 +13,7 @@ PackageName = cactuscore-uhal-python${PYTHON_VERSION_MAJOR_MINOR}
 
 PACKAGE_VER_MAJOR = 2
 PACKAGE_VER_MINOR = 8
-PACKAGE_VER_PATCH = 0
+PACKAGE_VER_PATCH = 1
 PACKAGE_RELEASE = 1${PACKAGE_RELEASE_SUFFIX}
 
 PackageDescription = Python bindings for the uHAL library

--- a/uhal/tests/Makefile
+++ b/uhal/tests/Makefile
@@ -10,7 +10,7 @@ PackageName = cactuscore-uhal-tests
 
 PACKAGE_VER_MAJOR = 2
 PACKAGE_VER_MINOR = 8
-PACKAGE_VER_PATCH = 0
+PACKAGE_VER_PATCH = 1
 PACKAGE_RELEASE = 1${PACKAGE_RELEASE_SUFFIX}
 
 PackageSummary = uHAL Library Tests

--- a/uhal/tools/Makefile
+++ b/uhal/tools/Makefile
@@ -10,7 +10,7 @@ PackageName = cactuscore-uhal-tools
 
 PACKAGE_VER_MAJOR = 2
 PACKAGE_VER_MINOR = 8
-PACKAGE_VER_PATCH = 0
+PACKAGE_VER_PATCH = 1
 PACKAGE_RELEASE = 1${PACKAGE_RELEASE_SUFFIX}
 
 PackageSummary = uTCA HW Development Tools that depend on uHAL

--- a/uhal/uhal/Makefile
+++ b/uhal/uhal/Makefile
@@ -10,7 +10,7 @@ PackageName = cactuscore-uhal-uhal
 
 PACKAGE_VER_MAJOR = 2
 PACKAGE_VER_MINOR = 8
-PACKAGE_VER_PATCH = 0
+PACKAGE_VER_PATCH = 1
 PACKAGE_RELEASE = 1${PACKAGE_RELEASE_SUFFIX}
 
 PackageSummary = uHAL Library

--- a/uhal/uhal/include/uhal/version.hpp
+++ b/uhal/uhal/include/uhal/version.hpp
@@ -30,15 +30,16 @@
 ---------------------------------------------------------------------------
 */
 
-/**
-	@file
-	@author Andrew W. Rose
-	@date 2012
-*/
+#ifndef _uhal_version_hpp_
+#define _uhal_version_hpp_
 
-#include "uhal/definitions.hpp"
-#include "uhal/ValMem.hpp"
-#include "uhal/ConnectionManager.hpp"
-#include "uhal/HwInterface.hpp"
-#include "uhal/Node.hpp"
-#include "uhal/version.hpp"
+
+#define UHAL_VERSION_MAJOR 2
+#define UHAL_VERSION_MINOR 8
+#define UHAL_VERSION_PATCH 1
+
+#define UHAL_VERSION (10000 * UHAL_VERSION_MAJOR + 100 * UHAL_VERSION_MINOR + UHAL_VERSION_PATCH)
+
+
+#endif
+


### PR DESCRIPTION
Adds version header with four macros:
```
UHAL_VERSION_MAJOR
UHAL_VERSION_MINOR
UHAL_VERSION_PATCH
UHAL_VERSION
```

Motivation: To allow people to write code that builds against multiple versions of uHAL, in rare cases where there may be backward changes to types/names (e.g. recent update to using C++11 built-in types instead of `boost::unordered_map` etc.).
