### PR TITLE
Remove env var requirement from mmap client

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,6 +15,7 @@ stages:
   - final_report
 
 variables:
+  GIT_CLONE_PATH: ${CI_BUILDS_DIR}/${CI_PROJECT_PATH}___
   GIT_SUBMODULE_STRATEGY: normal
   GITHUB_REPO_API_URL: "https://api.github.com/repos/ipbus/ipbus-software"
   IPBUS_DOCKER_REGISTRY: "gitlab-registry.cern.ch/ipbus/ipbus-docker"

--- a/ci/build-rpm.yml
+++ b/ci/build-rpm.yml
@@ -7,7 +7,6 @@
     - export REPO_DIR=${CI_PROJECT_DIR}/ci_results/repos/${OUTPUT_REPO_SUBDIR}
     - if [ -z "${CI_COMMIT_TAG}" ]; then export PACKAGE_RELEASE_SUFFIX=.autobuild_$(git log --pretty=format:'%h' -1) ; fi
   script:
-    - cd .. && sudo rm -rf ipbus-software___ && mv ipbus-software ipbus-software___ && mkdir ipbus-software && cd ipbus-software___
     - make -k Set=all BUILD_UHAL_PYTHON=0 BUILD_UHAL_GUI=0
     - make -k Set=all BUILD_UHAL_PYTHON=0 BUILD_UHAL_GUI=0 PACKAGE_RELEASE_SUFFIX=${PACKAGE_RELEASE_SUFFIX} rpm
     - make -C uhal/log generate_files
@@ -72,7 +71,6 @@ build:centos7-gcc8:
     - sed -i 's|cd ${ZIP_NAME}|cd ${ZIP_NAME}/${ZIP_NAME}|g' extern/pugixml/Makefile
     - git diff
   script:
-    - cd .. && sudo rm -rf ipbus-software___ && mv ipbus-software ipbus-software___ && mkdir ipbus-software && cd ipbus-software___
     - make -k Set=all BUILD_BOOST=1 BUILD_PUGIXML=1 BUILD_UHAL_PYTHON=0
     - make -k Set=all BUILD_BOOST=1 BUILD_PUGIXML=1 BUILD_UHAL_PYTHON=0 PACKAGE_RELEASE_SUFFIX=${PACKAGE_RELEASE_SUFFIX} rpm
     - mkdir -p ${REPO_DIR}

--- a/controlhub/Makefile
+++ b/controlhub/Makefile
@@ -32,7 +32,7 @@ Packager = Tom Williams
 
 PACKAGE_VER_MAJOR = 2
 PACKAGE_VER_MINOR = 8
-PACKAGE_VER_PATCH = 1
+PACKAGE_VER_PATCH = 2
 
 # This is the version number for the RPM packaging.
 PACKAGE_RELEASE = 1${PACKAGE_RELEASE_SUFFIX}

--- a/controlhub/ebin/controlhub.app
+++ b/controlhub/ebin/controlhub.app
@@ -10,7 +10,7 @@
 %%% ===========================================================================
 {application, controlhub,
  [{description, "Control Hub: multi-client packet routing for IPbus/UDP hardware"},
-   {vsn, "2.8.1"},
+   {vsn, "2.8.2"},
    {modules, [controlhub_app,
               ch_config,
               ch_sup,

--- a/controlhub/rel/reltool.config
+++ b/controlhub/rel/reltool.config
@@ -4,7 +4,7 @@
        {lib_dirs, []},
        {erts, [{mod_cond, derived}, {app_file, strip}]},
        {app_file, strip},
-       {rel, "controlhub", "2.8.1",
+       {rel, "controlhub", "2.8.2",
         [
          kernel,
          stdlib,

--- a/uhal/grammars/Makefile
+++ b/uhal/grammars/Makefile
@@ -10,7 +10,7 @@ PackageName = cactuscore-uhal-grammars
 
 PACKAGE_VER_MAJOR = 2
 PACKAGE_VER_MINOR = 8
-PACKAGE_VER_PATCH = 1
+PACKAGE_VER_PATCH = 2
 PACKAGE_RELEASE = 1${PACKAGE_RELEASE_SUFFIX}
 
 PackageSummary = uHAL Boost Spirit Grammars

--- a/uhal/gui/Makefile
+++ b/uhal/gui/Makefile
@@ -13,7 +13,7 @@ PackageName = cactuscore-uhal-python${PYTHON_VERSION_MAJOR_MINOR}-gui
 
 PACKAGE_VER_MAJOR = 2
 PACKAGE_VER_MINOR = 8
-PACKAGE_VER_PATCH = 1
+PACKAGE_VER_PATCH = 2
 PACKAGE_RELEASE = 1${PACKAGE_RELEASE_SUFFIX}
 
 PackageDescription = Python GUI for uTCA HW access based on uHAL

--- a/uhal/log/Makefile
+++ b/uhal/log/Makefile
@@ -10,7 +10,7 @@ PackageName = cactuscore-uhal-log
 
 PACKAGE_VER_MAJOR = 2
 PACKAGE_VER_MINOR = 8
-PACKAGE_VER_PATCH = 1
+PACKAGE_VER_PATCH = 2
 PACKAGE_RELEASE = 1${PACKAGE_RELEASE_SUFFIX}
 
 PackageSummary = uHAL Logging Library

--- a/uhal/python/Makefile
+++ b/uhal/python/Makefile
@@ -13,7 +13,7 @@ PackageName = cactuscore-uhal-python${PYTHON_VERSION_MAJOR_MINOR}
 
 PACKAGE_VER_MAJOR = 2
 PACKAGE_VER_MINOR = 8
-PACKAGE_VER_PATCH = 1
+PACKAGE_VER_PATCH = 2
 PACKAGE_RELEASE = 1${PACKAGE_RELEASE_SUFFIX}
 
 PackageDescription = Python bindings for the uHAL library

--- a/uhal/tests/Makefile
+++ b/uhal/tests/Makefile
@@ -10,7 +10,7 @@ PackageName = cactuscore-uhal-tests
 
 PACKAGE_VER_MAJOR = 2
 PACKAGE_VER_MINOR = 8
-PACKAGE_VER_PATCH = 1
+PACKAGE_VER_PATCH = 2
 PACKAGE_RELEASE = 1${PACKAGE_RELEASE_SUFFIX}
 
 PackageSummary = uHAL Library Tests

--- a/uhal/tools/Makefile
+++ b/uhal/tools/Makefile
@@ -10,7 +10,7 @@ PackageName = cactuscore-uhal-tools
 
 PACKAGE_VER_MAJOR = 2
 PACKAGE_VER_MINOR = 8
-PACKAGE_VER_PATCH = 1
+PACKAGE_VER_PATCH = 2
 PACKAGE_RELEASE = 1${PACKAGE_RELEASE_SUFFIX}
 
 PackageSummary = uTCA HW Development Tools that depend on uHAL

--- a/uhal/uhal/Makefile
+++ b/uhal/uhal/Makefile
@@ -10,7 +10,7 @@ PackageName = cactuscore-uhal-uhal
 
 PACKAGE_VER_MAJOR = 2
 PACKAGE_VER_MINOR = 8
-PACKAGE_VER_PATCH = 1
+PACKAGE_VER_PATCH = 2
 PACKAGE_RELEASE = 1${PACKAGE_RELEASE_SUFFIX}
 
 PackageSummary = uHAL Library

--- a/uhal/uhal/src/common/ProtocolMmap.cpp
+++ b/uhal/uhal/src/common/ProtocolMmap.cpp
@@ -263,13 +263,6 @@ Mmap::Mmap ( const std::string& aId, const URI& aUri ) :
   mReadReplyPageCount(0),
   mAsynchronousException ( NULL )
 {
-  if ( getenv("UHAL_ENABLE_IPBUS_MMAP") == NULL ) {
-    exception::ProtocolDoesNotExist lExc;
-    log(lExc, "The IPbus 2.0 mmap client is still an experimental feature, since the software-driver interface could change in the future.");
-    log(lExc, "In order to enable the IPbus 2.0 mmap client, you need to define the environment variable 'UHAL_ENABLE_IPBUS_MMAP'");
-    throw lExc;
-  }
-
   mSleepDuration = std::chrono::microseconds(50);
 
   for (const auto& lArg: aUri.mArguments) {


### PR DESCRIPTION
Since the client remained unchanged for a long time now, remove requirement that `UHAL_ENABLE_IPBUS_MMAP` variable be defined to use it