### PR TITLE
uHAL: Fix RHEL8 RPM build error

### DIFF
--- a/controlhub/Makefile
+++ b/controlhub/Makefile
@@ -32,7 +32,7 @@ Packager = Tom Williams
 
 PACKAGE_VER_MAJOR = 2
 PACKAGE_VER_MINOR = 8
-PACKAGE_VER_PATCH = 2
+PACKAGE_VER_PATCH = 3
 
 # This is the version number for the RPM packaging.
 PACKAGE_RELEASE = 1${PACKAGE_RELEASE_SUFFIX}
@@ -88,6 +88,8 @@ else
 endif
 
 
+RPM_DIST = $(patsubst %.cern,%,$(shell rpm --eval "%{dist}"))
+
 rpm: _rpmall
 _rpmall: build
 	mkdir -p ${RPMBUILD_DIR}/{RPMS/{i386,i586,i686,x86_64},SPECS,BUILD,SOURCES/{lib,bin},SRPMS}
@@ -111,7 +113,7 @@ endif
 		--define "sources_dir ${RPMBUILD_SOURCES_DIR}" \
 		--define "name ${PackageName}" \
 		--define "version ${PACKAGE_VER_MAJOR}.${PACKAGE_VER_MINOR}.${PACKAGE_VER_PATCH}" \
-		--define "release ${PACKAGE_RELEASE}.${CACTUS_OS}" \
+		--define "release ${PACKAGE_RELEASE}${RPM_DIST}" \
 		--define "packager ${Packager}" \
 		${PackageName}.spec
 	find  ${RPMBUILD_DIR} -name "*.rpm" -exec mv {} $(PackagePath)/rpm \;

--- a/uhal/config/mfPythonRPMRules.mk
+++ b/uhal/config/mfPythonRPMRules.mk
@@ -10,7 +10,8 @@ PackageURL ?= None
 
 CACTUS_ROOT ?= /opt/cactus
 
-RPM_RELEASE_SUFFIX = ${CACTUS_OS}$(if ${CXX_VERSION_TAG},.${CXX_VERSION_TAG},)
+RPM_DIST = $(patsubst %.cern,%,$(shell rpm --eval "%{dist}"))
+RPM_RELEASE_SUFFIX = ${RPM_DIST}$(if ${CXX_VERSION_TAG},.${CXX_VERSION_TAG},)
 
 PYTHON_MAJOR_COMMAND := $(shell ${PYTHON} -c "import sys; print('python{}'.format(sys.version_info.major))")
 PYTHON_VERSIONED_COMMAND := $(shell ${PYTHON} -c "import sys; print('python{}.{}'.format(sys.version_info.major,sys.version_info.minor))")
@@ -45,7 +46,7 @@ _rpmbuild: _setup_update
 	cd ${RPMBUILD_DIR} && \
 	  LIB_REQUIRES=$$(find ${RPMBUILD_DIR} -type f -print0 | xargs -0 -n1 -I {} file {} \; | grep -v text | cut -d: -f1 | /usr/lib/rpm/find-requires | tr '\n' ' ') && \
 	  ${PYTHON} ${PackageName}.py bdist_rpm --spec-only \
-	    --release ${PACKAGE_RELEASE}.${RPM_RELEASE_SUFFIX} \
+	    --release ${PACKAGE_RELEASE}${RPM_RELEASE_SUFFIX} \
 	    --requires "${PYTHON_RPM_CAPABILITY} $$LIB_REQUIRES" \
 	    --force-arch=${BUILD_ARCH} \
 	    --binary-only

--- a/uhal/config/mfRPMRules.mk
+++ b/uhal/config/mfRPMRules.mk
@@ -8,7 +8,8 @@ PackageDescription := $(if ${PackageDescription}, ${PackageDescription}, None)
 BUILD_REQUIRES_TAG = $(if ${PackageBuildRequires} ,BuildRequires: ${PackageBuildRequires} ,\# No BuildRequires tag )
 REQUIRES_TAG = $(if ${PackageRequires} ,Requires: ${PackageRequires} ,\# No Requires tag )
 
-RPM_RELEASE_SUFFIX = ${CACTUS_OS}$(if ${CXX_VERSION_TAG},.${CXX_VERSION_TAG},)
+RPM_DIST = $(patsubst %.cern,%,$(shell rpm --eval "%{dist}"))
+RPM_RELEASE_SUFFIX = ${RPM_DIST}$(if ${CXX_VERSION_TAG},.${CXX_VERSION_TAG},)
 
 PYTHON_VERSIONED_COMMAND := $(shell ${PYTHON} -c "from sys import version_info; print('python' + str(version_info[0]))")
 
@@ -31,11 +32,10 @@ _spec_update:
 	sed -i -e 's#__package__#${Package}#' \
 	       -e 's#__packagename__#${PackageName}#' \
 	       -e 's#__version__#$(PACKAGE_VER_MAJOR).$(PACKAGE_VER_MINOR).$(PACKAGE_VER_PATCH)#' \
-	       -e 's#__release__#${PACKAGE_RELEASE}.${RPM_RELEASE_SUFFIX}#' \
+	       -e 's#__release__#${PACKAGE_RELEASE}${RPM_RELEASE_SUFFIX}#' \
 	       -e 's#__prefix__#${CACTUS_ROOT}#' \
 	       -e 's#__sources_dir__#${RPMBUILD_DIR}/SOURCES#' \
 	       -e 's#__packagedir__#${PackagePath}#' \
-	       -e 's#__os__#${CACTUS_OS}#' \
 	       -e 's#__platform__#None#' \
 	       -e 's#__project__#${Project}#' \
 	       -e 's#__author__#${Packager}#' \

--- a/uhal/config/specTemplate.spec
+++ b/uhal/config/specTemplate.spec
@@ -6,7 +6,6 @@
 %define _sources_dir __sources_dir__
 %define _tmppath /tmp
 %define _packagedir __packagedir__
-%define _os __os__
 %define _project __project__
 %define _author __author__
 %define _summary __summary__
@@ -25,7 +24,7 @@
 #
 Name: %{_packagename} 
 Version: %{_version} 
-Release: %{_release} 
+Release: %{_release}
 Packager: %{_author}
 Summary: %{_summary}
 License: GPLv3
@@ -131,8 +130,8 @@ find ./ -type d -exec chmod 755 {} \;
 %{_prefix}/include
 
 %if %{defined _build_debuginfo_package}
-# Temporary workaround for subpackages not being built on CentOS8
-%if %{_os} != centos8
+# Temporary workaround for subpackages not being built on RHEL8, CentOS8, etc.
+%if "%{dist}" != ".el8"
 %files debuginfo
 %defattr(-,root,root,-)
 %endif

--- a/uhal/grammars/Makefile
+++ b/uhal/grammars/Makefile
@@ -10,7 +10,7 @@ PackageName = cactuscore-uhal-grammars
 
 PACKAGE_VER_MAJOR = 2
 PACKAGE_VER_MINOR = 8
-PACKAGE_VER_PATCH = 2
+PACKAGE_VER_PATCH = 3
 PACKAGE_RELEASE = 1${PACKAGE_RELEASE_SUFFIX}
 
 PackageSummary = uHAL Boost Spirit Grammars

--- a/uhal/gui/Makefile
+++ b/uhal/gui/Makefile
@@ -13,7 +13,7 @@ PackageName = cactuscore-uhal-python${PYTHON_VERSION_MAJOR_MINOR}-gui
 
 PACKAGE_VER_MAJOR = 2
 PACKAGE_VER_MINOR = 8
-PACKAGE_VER_PATCH = 2
+PACKAGE_VER_PATCH = 3
 PACKAGE_RELEASE = 1${PACKAGE_RELEASE_SUFFIX}
 
 PackageDescription = Python GUI for uTCA HW access based on uHAL

--- a/uhal/log/Makefile
+++ b/uhal/log/Makefile
@@ -10,7 +10,7 @@ PackageName = cactuscore-uhal-log
 
 PACKAGE_VER_MAJOR = 2
 PACKAGE_VER_MINOR = 8
-PACKAGE_VER_PATCH = 2
+PACKAGE_VER_PATCH = 3
 PACKAGE_RELEASE = 1${PACKAGE_RELEASE_SUFFIX}
 
 PackageSummary = uHAL Logging Library

--- a/uhal/python/Makefile
+++ b/uhal/python/Makefile
@@ -13,7 +13,7 @@ PackageName = cactuscore-uhal-python${PYTHON_VERSION_MAJOR_MINOR}
 
 PACKAGE_VER_MAJOR = 2
 PACKAGE_VER_MINOR = 8
-PACKAGE_VER_PATCH = 2
+PACKAGE_VER_PATCH = 3
 PACKAGE_RELEASE = 1${PACKAGE_RELEASE_SUFFIX}
 
 PackageDescription = Python bindings for the uHAL library

--- a/uhal/tests/Makefile
+++ b/uhal/tests/Makefile
@@ -10,7 +10,7 @@ PackageName = cactuscore-uhal-tests
 
 PACKAGE_VER_MAJOR = 2
 PACKAGE_VER_MINOR = 8
-PACKAGE_VER_PATCH = 2
+PACKAGE_VER_PATCH = 3
 PACKAGE_RELEASE = 1${PACKAGE_RELEASE_SUFFIX}
 
 PackageSummary = uHAL Library Tests

--- a/uhal/tools/Makefile
+++ b/uhal/tools/Makefile
@@ -10,7 +10,7 @@ PackageName = cactuscore-uhal-tools
 
 PACKAGE_VER_MAJOR = 2
 PACKAGE_VER_MINOR = 8
-PACKAGE_VER_PATCH = 2
+PACKAGE_VER_PATCH = 3
 PACKAGE_RELEASE = 1${PACKAGE_RELEASE_SUFFIX}
 
 PackageSummary = uTCA HW Development Tools that depend on uHAL

--- a/uhal/uhal/Makefile
+++ b/uhal/uhal/Makefile
@@ -10,7 +10,7 @@ PackageName = cactuscore-uhal-uhal
 
 PACKAGE_VER_MAJOR = 2
 PACKAGE_VER_MINOR = 8
-PACKAGE_VER_PATCH = 2
+PACKAGE_VER_PATCH = 3
 PACKAGE_RELEASE = 1${PACKAGE_RELEASE_SUFFIX}
 
 PackageSummary = uHAL Library


### PR DESCRIPTION
Fixes #261

At the same time, I changed the `.centosN` release field suffix to the standard `.elN`, taken from the RPM `dist` variable