### PR TITLE
Minor build fixes

### DIFF
--- a/config/Makefile.macros
+++ b/config/Makefile.macros
@@ -11,14 +11,9 @@ CACTUS_OS=unknown.os
 
 UNAME=$(strip $(shell uname -s))
 ifeq ($(UNAME),Linux)
-    ifneq ($(findstring Scientific Linux CERN SLC release 6,$(CACTUS_PLATFORM)),)
-        CACTUS_OS=slc6
-    else ifneq ($(findstring CentOS Linux release 7,$(CACTUS_PLATFORM)),)
-        CACTUS_OS=el7
-    else ifneq ($(findstring CentOS Linux release 8,$(CACTUS_PLATFORM)),)
-        CACTUS_OS=el8
-    else ifneq ($(findstring CentOS Stream release 8,$(CACTUS_PLATFORM)),)
-        CACTUS_OS=el8
+    CACTUS_OS_EL_MAJOR=$(shell cat /etc/system-release | sed 's/^\(CentOS Linux\|CentOS Stream\|AlmaLinux|Rocky Linux\) release \([0-9]\).*/\2/;t;d')
+    ifneq ($(CACTUS_OS_EL_MAJOR),)
+        CACTUS_OS=el$(CACTUS_OS_EL_MAJOR)
     endif
 else ifeq ($(UNAME),Darwin)
     CACTUS_OS=osx

--- a/config/Makefile.macros
+++ b/config/Makefile.macros
@@ -17,6 +17,8 @@ ifeq ($(UNAME),Linux)
         CACTUS_OS=centos7
     else ifneq ($(findstring CentOS Linux release 8,$(CACTUS_PLATFORM)),)
         CACTUS_OS=centos8
+    else ifneq ($(findstring CentOS Stream release 8,$(CACTUS_PLATFORM)),)
+        CACTUS_OS=centos8
     endif
 else ifeq ($(UNAME),Darwin)
     CACTUS_OS=osx

--- a/config/Makefile.macros
+++ b/config/Makefile.macros
@@ -14,11 +14,11 @@ ifeq ($(UNAME),Linux)
     ifneq ($(findstring Scientific Linux CERN SLC release 6,$(CACTUS_PLATFORM)),)
         CACTUS_OS=slc6
     else ifneq ($(findstring CentOS Linux release 7,$(CACTUS_PLATFORM)),)
-        CACTUS_OS=centos7
+        CACTUS_OS=el7
     else ifneq ($(findstring CentOS Linux release 8,$(CACTUS_PLATFORM)),)
-        CACTUS_OS=centos8
+        CACTUS_OS=el8
     else ifneq ($(findstring CentOS Stream release 8,$(CACTUS_PLATFORM)),)
-        CACTUS_OS=centos8
+        CACTUS_OS=el8
     endif
 else ifeq ($(UNAME),Darwin)
     CACTUS_OS=osx

--- a/controlhub/Makefile
+++ b/controlhub/Makefile
@@ -81,7 +81,7 @@ else
 	REBAR=$(shell pwd)/legacy/rebar
 endif
 
-ifeq (${CACTUS_OS}, centos7)
+ifeq (${CACTUS_OS}, el7)
     RPMSPEC_SNIPPET_OS_TAG=rhel7
 else
     RPMSPEC_SNIPPET_OS_TAG=rhelLeq6
@@ -97,7 +97,7 @@ _rpmall: build
 	cp scripts/controlhub_* ${RPMBUILD_SOURCES_DIR}/bin
 	cp pkg/rsyslog.d.conf ${RPMBUILD_SOURCES_DIR}/ 
 	cp pkg/logrotate.d.conf ${RPMBUILD_SOURCES_DIR}/
-ifneq ($(CACTUS_OS),centos7)
+ifneq ($(CACTUS_OS),el7)
 	cp pkg/init.d ${RPMBUILD_SOURCES_DIR}/controlhub
 else
 	cp pkg/systemd/controlhub.service ${RPMBUILD_SOURCES_DIR}/

--- a/uhal/config/mfPythonRPMRules.mk
+++ b/uhal/config/mfPythonRPMRules.mk
@@ -38,7 +38,7 @@ _rpmall: _all _setup_update _rpmbuild
 .PHONY: _rpmbuild
 _rpmbuild: _setup_update
 	find pkg -not -type d -printf '%P\0' | xargs -0 -n1 -I {} install -D pkg/{} ${RPMBUILD_DIR}/{}
-	find scripts etc -not -type d -printf '%p\0' | xargs -0 -n1 -I {} cp --parents {} ${RPMBUILD_DIR}
+	if [ -d etc -o -d scripts ]; then find scripts etc -not -type d -printf '%p\0' | xargs -0 -n1 -I {} cp --parents {} ${RPMBUILD_DIR}; fi
 	find ${RPMBUILD_DIR} -type f -exec sed -i "s|#!/usr/bin/env python|#!/usr/bin/env "${PYTHON_VERSIONED_COMMAND}"|" {} \;
 	# Add a manifest file
 	echo "include */*.so" > ${RPMBUILD_DIR}/MANIFEST.in

--- a/uhal/config/mfRPMRules.mk
+++ b/uhal/config/mfRPMRules.mk
@@ -23,7 +23,7 @@ _rpmall: _all _spec_update _rpmbuild
 _rpmbuild: _spec_update
 	mkdir -p ${RPMBUILD_DIR}/{RPMS/{i386,i586,i686,x86_64},SPECS,BUILD,SOURCES,SRPMS}
 	rpmbuild --quiet -bb -bl --buildroot=${RPMBUILD_DIR}/BUILD --define  "_topdir ${RPMBUILD_DIR}" rpm/${PackageName}.spec
-	find ${RPMBUILD_DIR} -name "*.rpm" -print0 | xargs -0 -n1 -I {} mv {} rpm/
+	find ${RPMBUILD_DIR} -name "*.rpm" -print0 | xargs -0 -I {} mv {} rpm/
 
 .PHONY: _spec_update
 _spec_update:

--- a/uhal/config/specTemplate.spec
+++ b/uhal/config/specTemplate.spec
@@ -76,6 +76,9 @@ if [ "${#DEBUGDIR}" -gt "${#PKGDIR}" ]; then
 fi
 %endif
 
+# Change working directory to avoid "shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory" error
+cd $RPM_BUILD_ROOT
+
 if [ -d %{_packagedir}/bin ]; then
   find %{_packagedir}/bin -type f -printf '%{percent}P\0' | xargs -0 -n1 -I {} $BUILD_HOME/uhal/config/install.sh %{_packagedir}/bin/{} %{_prefix}/bin/%{_project}/{} 755 $RPM_BUILD_ROOT %{_packagedir} %{_packagename} %{_version} %{_prefix}/include '%{_includedirs}'
 fi

--- a/uhal/config/specTemplate.spec
+++ b/uhal/config/specTemplate.spec
@@ -80,27 +80,27 @@ fi
 cd $RPM_BUILD_ROOT
 
 if [ -d %{_packagedir}/bin ]; then
-  find %{_packagedir}/bin -type f -printf '%{percent}P\0' | xargs -0 -n1 -I {} $BUILD_HOME/uhal/config/install.sh %{_packagedir}/bin/{} %{_prefix}/bin/%{_project}/{} 755 $RPM_BUILD_ROOT %{_packagedir} %{_packagename} %{_version} %{_prefix}/include '%{_includedirs}'
+  find %{_packagedir}/bin -type f -printf '%{percent}P\0' | xargs -0 -I {} $BUILD_HOME/uhal/config/install.sh %{_packagedir}/bin/{} %{_prefix}/bin/%{_project}/{} 755 $RPM_BUILD_ROOT %{_packagedir} %{_packagename} %{_version} %{_prefix}/include '%{_includedirs}'
 fi
 
 if [ -d %{_packagedir}/scripts ]; then
-  find %{_packagedir}/scripts -type f -printf '%{percent}P\0' | xargs -0 -n1 -I {} install -D -m 755 %{_packagedir}/scripts/{} $RPM_BUILD_ROOT/%{_prefix}/bin/%{_project}/{}
-  find $RPM_BUILD_ROOT/%{_prefix}/bin/%{_project} -type f -print0 | xargs -0 -n1 -I {} sed -i "s|#!/usr/bin/env python|#!/usr/bin/env "%{_python_versioned_command}"|" {}
+  find %{_packagedir}/scripts -type f -printf '%{percent}P\0' | xargs -0 -I {} install -D -m 755 %{_packagedir}/scripts/{} $RPM_BUILD_ROOT/%{_prefix}/bin/%{_project}/{}
+  find $RPM_BUILD_ROOT/%{_prefix}/bin/%{_project} -type f -print0 | xargs -0 -I {} sed -i "s|#!/usr/bin/env python|#!/usr/bin/env "%{_python_versioned_command}"|" {}
 fi
 
 if [ -d %{_packagedir}/lib ]; then
-  find %{_packagedir}/lib -type f -printf '%{percent}P\0' | xargs -0 -n1 -I {} $BUILD_HOME/uhal/config/install.sh %{_packagedir}/lib/{} %{_prefix}/lib/{} 655 $RPM_BUILD_ROOT %{_packagedir} %{_packagename} %{_version} %{_prefix}/include '%{_includedirs}' \;
-  find %{_packagedir}/lib -type l -printf '%{percent}P\0' | xargs -0 -n1 -I {} sh -c 'ln -s -f %{_prefix}/lib/$(basename $(readlink %{_packagedir}/lib/$0)) $RPM_BUILD_ROOT/%{_prefix}/lib/$0' {}
+  find %{_packagedir}/lib -type f -printf '%{percent}P\0' | xargs -0 -I {} $BUILD_HOME/uhal/config/install.sh %{_packagedir}/lib/{} %{_prefix}/lib/{} 655 $RPM_BUILD_ROOT %{_packagedir} %{_packagename} %{_version} %{_prefix}/include '%{_includedirs}' \;
+  find %{_packagedir}/lib -type l -printf '%{percent}P\0' | xargs -0 -I {} sh -c 'ln -s -f %{_prefix}/lib/$(basename $(readlink %{_packagedir}/lib/$0)) $RPM_BUILD_ROOT/%{_prefix}/lib/$0' {}
 fi
 
 
 if [ -d %{_packagedir}/include ]; then
-  find %{_packagedir}/include -type f -printf '%{percent}P\0' | xargs -0 -n1 -I {} install -D -m 644 %{_packagedir}/include/{} $RPM_BUILD_ROOT/%{_prefix}/include/{}
+  find %{_packagedir}/include -type f -printf '%{percent}P\0' | xargs -0 -I {} install -D -m 644 %{_packagedir}/include/{} $RPM_BUILD_ROOT/%{_prefix}/include/{}
 fi
 
 
 if [ -d %{_packagedir}/etc ]; then
-  find %{_packagedir}/etc -type f -printf '%{percent}P\0' | xargs -0 -n1 -I {} install -D -m 644 %{_packagedir}/etc/{} $RPM_BUILD_ROOT/%{_prefix}/etc/{}
+  find %{_packagedir}/etc -type f -printf '%{percent}P\0' | xargs -0 -I {} install -D -m 644 %{_packagedir}/etc/{} $RPM_BUILD_ROOT/%{_prefix}/etc/{}
 fi
 
 #create debug.source - SLC6 beardy wierdo "feature"

--- a/uhal/config/specTemplate.spec
+++ b/uhal/config/specTemplate.spec
@@ -133,8 +133,8 @@ find ./ -type d -exec chmod 755 {} \;
 %{_prefix}/include
 
 %if %{defined _build_debuginfo_package}
-# Temporary workaround for subpackages not being built on RHEL8, CentOS8, etc.
-%if "%{dist}" != ".el8"
+# Temporary workaround for subpackages not being built on RHEL8, CentOS8, RHEL9, Alma9 etc.
+%if "%{dist}" != ".el8" && "%{dist}" != ".el9"
 %files debuginfo
 %defattr(-,root,root,-)
 %endif


### PR DESCRIPTION
 * Update `CACTUS_OS` variable for builds on CentOS8 stream
 * Fix the following irritating warning message in RPM build process:
 ```
shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
```
 * Fixes for Alma 9