### PR TITLE
Fix ProtocolMmap so that it can forget and forgive after a failure

### DIFF
--- a/uhal/uhal/src/common/ProtocolMmap.cpp
+++ b/uhal/uhal/src/common/ProtocolMmap.cpp
@@ -463,6 +463,7 @@ void Mmap::read()
 
 
   // PART 3 : Validate the packet contents
+  mAsynchronousException = NULL;
   try
   {
     if ( uhal::exception::exception* lExc = ClientInterface::validate ( lBuffers ) ) //Control of the pointer has been passed back to the client interface


### PR DESCRIPTION
This effectively zeros mAsynchronousException in Mmap::read(), which mistakenly stored the last exception encountered and kept failing on that one.

After tracking down why things were failing, and fixing the issue, I actually find this quite hilarious, because:
  https://github.com/ipbus/ipbus-software/commit/a31dbe2906fe4828c1a671e194ef0bd086a3a03d

It would actually be good if the Mmap protocol implementation would evolve in the same way the PCIe protocol has.