### PR TITLE
ControlHub: Add support for device allowlist file

### DIFF
--- a/controlhub/ebin/controlhub.app
+++ b/controlhub/ebin/controlhub.app
@@ -38,6 +38,9 @@
           % The timeout (ms) used when waiting for a response from a hardware target.
           {device_response_timeout, 20},
           % The time (ms) after which a device client process will shut down if not communicating with board
-          {device_client_shutdown_after, 15000}]}
+          {device_client_shutdown_after, 15000},
+          % Device allowlist: File path and mode
+          {device_allowlist_mode, enforcing},
+          {device_allowlist_file, none}]}
  ]
 }.

--- a/controlhub/include/ch_error_codes.hrl
+++ b/controlhub/include/ch_error_codes.hrl
@@ -28,3 +28,6 @@
 
 % Implies that device client probably died (i.e. a ControlHub problem).
 -define(ERRCODE_CH_DEVICE_CLIENT_TIMEOUT, 2).
+
+% Implies that sending IPbus request to a target that is not in the allow list.
+-define(ERRCODE_TARGET_BLOCKED, 7).

--- a/controlhub/rel/files/nodetool
+++ b/controlhub/rel/files/nodetool
@@ -77,10 +77,16 @@ main(Args) ->
             io:format("Device client parameters ...~n"
                       "    max packets in flight to each board = ~w~n"
                       "    timeout for replies from board = ~wms~n"
-                      "    device client lifetime when inactive = ~wms~n~n",
+                      "    device client lifetime when inactive = ~wms~n",
                       [proplists:get_value(max_udp_in_flight, InfoList, unknown),
                        proplists:get_value(device_response_timeout, InfoList, unknown),
                        proplists:get_value(device_client_shutdown_after, InfoList, unknown)]),
+            case proplists:get_value(device_allowlist_file, InfoList, unknown) of
+                none ->
+                    io:format("    no allowlist defined~n~n");
+                FilePath ->
+                    io:format("    allowlist file \"~s\" (mode: ~w)~n~n", [FilePath, proplists:get_value(device_allowlist_mode, InfoList, unknown)])
+            end,
             io:format("TCP parameters ...~n"
                       "    Listening on port ~w~n",
                       [proplists:get_value(tcp_listen_port, InfoList, unknown)]);

--- a/controlhub/src/ch_config.erl
+++ b/controlhub/src/ch_config.erl
@@ -13,11 +13,12 @@
 
 %% Exported functions
 
--export([init/0, get/1, get_start_time/0, get_parameter_names/0]).
+-export([init/0, get/1, get_start_time/0, get_parameter_names/0, get_device_access_status/2]).
 
 -type config_param() :: config_file | app_start_timestamp
                        | tcp_listen_port | tcp_socket_opts
-                       | max_udp_in_flight | device_response_timeout | device_client_shutdown_after .
+                       | max_udp_in_flight | device_response_timeout | device_client_shutdown_after
+                       | device_allowlist | device_allowlist_file | device_allowlist_mode .
 
 
 -define(TCP_SOCKET_OPTS, [binary, {packet, 4}, {reuseaddr, true}, {nodelay, true}, {active, true}, {backlog, 256}, {buffer, 200000}, {low_watermark, 200000}, {high_watermark, 400000}, {recbuf, 200000}, {sndbuf, 200000}]).
@@ -49,7 +50,21 @@ init() ->
     set_param_from_ch_env(max_udp_in_flight),
     set_param_from_ch_env(device_response_timeout),
     set_param_from_ch_env(device_client_shutdown_after),
-    ok.
+    set_param_from_ch_env(device_allowlist_mode),
+    set_param_from_ch_env(device_allowlist_file),
+    case get_app_env(controlhub, device_allowlist_file) of
+        none ->
+            set_param(device_allowlist, none),
+            ok;
+        FilePath ->
+            case parse_device_allowlist(FilePath) of
+                {error, ErrorMessage} ->
+                    {stop, ErrorMessage};
+                {ok, AllowList} ->
+                    set_param(device_allowlist, AllowList),
+                    ok
+            end
+    end.
 
 
 %% ------------------------------------------------------------------------------------
@@ -80,7 +95,27 @@ get_start_time() ->
 
 -spec get_parameter_names() -> [any()].
 get_parameter_names() ->
-    [tcp_listen_port, tcp_socket_opts, max_udp_in_flight, device_response_timeout, device_client_shutdown_after].
+    [tcp_listen_port, tcp_socket_opts, max_udp_in_flight,
+     device_response_timeout, device_client_shutdown_after,
+     device_allowlist, device_allowlist_file, device_allowlist_mode].
+
+
+get_device_access_status(IPAddr, Port) ->
+    case ?MODULE:get(device_allowlist) of
+        none ->
+            allow;
+        AllowDict ->
+            case dict:find(IPAddr, AllowDict) of
+                {ok, any} ->
+                    allow;
+                {ok, Port} ->
+                    allow;
+                {ok, _AnotherPort} ->
+                    deny;
+                error ->
+                    deny
+            end
+    end.
 
 
 %% Internal functions
@@ -104,3 +139,50 @@ set_param(Param, Value) ->
 set_param_from_ch_env(Param) ->
     set_param(Param, get_app_env(controlhub, Param)).
 
+
+parse_device_allowlist(FilePath) ->
+    {ok, File} = file:open(FilePath, [read]),
+    parse_device_allowlist(File, dict:new(), 1).
+
+parse_device_allowlist(File, Dict, LineNumber) ->
+    case file:read_line(File) of
+        {ok, Line} ->
+            TrimmedLine = string:strip(string:strip(string:strip(Line, both, $\n), both, $\t), both, $ ),
+            % ch_utils:log(debug, "allowlist, line ~w: \"~s\"", [LineNumber, TrimmedLine]),
+            case TrimmedLine of
+                % Lines starting with '#' are comments - ignore them (# = 35)
+                [35 | _] ->
+                    parse_device_allowlist(File, Dict, LineNumber + 1);
+                % Also lines that were empty or just contained spaces (removed by string:strip)
+                [] ->
+                    parse_device_allowlist(File, Dict, LineNumber + 1);
+                % All other lines
+                _ ->
+                    case re:run(TrimmedLine, "[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}(?::[0-9]+)?") of
+                        {match, _} ->
+                            case re:split(TrimmedLine, "[\.:]", [{return, list}]) of
+                                [IP1Str, IP2Str, IP3Str, IP4Str] ->
+                                    IP1 = element(1, string:to_integer(IP1Str)),
+                                    IP2 = element(1, string:to_integer(IP2Str)),
+                                    IP3 = element(1, string:to_integer(IP3Str)),
+                                    IP4 = element(1, string:to_integer(IP4Str)),
+                                    ch_utils:log(debug, "Device allowlist: Adding ~w.~w.~w.~w (any port) ", [IP1, IP2, IP3, IP4]),
+                                    NewDict = dict:store({IP1, IP2, IP3, IP4}, any, Dict);
+                                [IP1Str, IP2Str, IP3Str, IP4Str, PortStr] ->
+                                    IP1 = element(1, string:to_integer(IP1Str)),
+                                    IP2 = element(1, string:to_integer(IP2Str)),
+                                    IP3 = element(1, string:to_integer(IP3Str)),
+                                    IP4 = element(1, string:to_integer(IP4Str)),
+                                    Port = element(1, string:to_integer(PortStr)),
+                                    ch_utils:log(debug, "Device allowlist: Adding ~w.~w.~w.~w:~w", [IP1, IP2, IP3, IP4, Port]),
+                                    NewDict = dict:store({IP1, IP2, IP3, IP4}, Port, Dict)
+                            end,
+                            parse_device_allowlist(File, NewDict, LineNumber + 1);
+                        nomatch ->
+                            ch_utils:log(error, "Line ~w of allowlist file doesn't match expected format", [LineNumber]),
+                            {error, io:format("Line ~w of allowlist file doesn't match expected format", [LineNumber])}
+                    end
+            end;
+        eof ->
+            {ok, Dict}
+    end.

--- a/controlhub/src/ch_device_client.erl
+++ b/controlhub/src/ch_device_client.erl
@@ -149,8 +149,8 @@ init([IPaddrU32, PortU16, ChMaxInFlight]) ->
     IPTuple = ch_utils:ipv4_u32_addr_to_tuple(IPaddrU32),
     put(target_ip_tuple, IPTuple),   
     put(target_port, PortU16),
-    ch_utils:log(debug, "Initialising device client for target at ~w:~w. Absolute max nr packets in flight is ~w.", 
-                 [ChMaxInFlight]),
+    ch_utils:log(debug, "Initialising device client for target at ~w.~w.~w.~w:~w. Absolute max nr packets in flight is ~w.",
+                 [element(1, IPTuple), element(2, IPTuple), element(3, IPTuple), element(4, IPTuple), PortU16, ChMaxInFlight]),
 
     % Try opening ephemeral port and we want data delivered as a binary.
     case gen_udp:open(0, [binary, {active, true}, {buffer, 100000}, {recbuf, 100000}, {read_packets, 50}]) of   

--- a/controlhub/src/ch_stats.erl
+++ b/controlhub/src/ch_stats.erl
@@ -275,7 +275,9 @@ get_app_info() ->
      {tcp_socket_opts, ch_config:get(tcp_socket_opts)},
      {max_udp_in_flight, ch_config:get(max_udp_in_flight)},
      {device_response_timeout, ch_config:get(device_response_timeout)},
-     {device_client_shutdown_after, ch_config:get(device_client_shutdown_after)}
+     {device_client_shutdown_after, ch_config:get(device_client_shutdown_after)},
+     {device_allowlist_mode, ch_config:get(device_allowlist_mode)},
+     {device_allowlist_file, ch_config:get(device_allowlist_file)}
     ].
 
 

--- a/uhal/uhal/src/common/ProtocolControlHub.cpp
+++ b/uhal/uhal/src/common/ProtocolControlHub.cpp
@@ -321,6 +321,9 @@ namespace uhal
       case 6:
         aStream << "request uses incorrect protocol version";
         break;
+      case 7:
+        aStream << "device is not in the ControlHub's allowlist";
+        break;
       default:
         aStream << "UNKNOWN";
     }


### PR DESCRIPTION
This branch adds support for restricting devices to a specific set of IP addresses, and optionally also specific ports - i.e. a device allowlist.

The allowlist path is specified in ControlHub config file using a new setting: `device_allowlist_file`. By default, no allowlist is used. The allowlist file is a plaintext file with one IP address or IP address + port per line; comments can be added using `#`. For example:
```
# A comment
1.2.3.4
5.6.7.8:9999

# Another address
127.0.0.1
```
If the port is not specified in the allowlist, then communication to any port at that IP address will be allowed.

There are two allowlist modes, which determine how it is applied: `enforcing` and `permissive`. In `enforcing` mode, the ControlHub will refuse to forward packets to a device unless it has been included in the allowlist  - the ControlHub will send an appropriate error code to uHAL, which will cause uHAL to throw an exception with the following message:
```
The ControlHub returned error code 0x0007 = target is not in the ControlHub's allowlist for target with URI "chtcp-2.0://localhost:10203?target=localhost:50001"
```
In `permissive` mode, the ControlHub will forward packets to any IP address & port, but a log message will be printed in the ControlHub log file each time that one tries to communicate with a device that is not in the allowlist - e.g:
```
Packets are being sent to device at  127.0.0.1:50001, which is not in the allowlist (running in permissive mode though, so still sending the packet).
```
Example config file for running in permissive mode, with allowlist at 
```
[
  %% Take application-level settings (e.g. for logging) from 'core.config' file
  "/opt/cactus/lib/controlhub/core.config",

  %% Override default values of ControlHub settings
  {controlhub, [
    {device_allowlist_file, "/etc/controlhub/allowlist.txt"},
    {device_allowlist_mode, permissive}
  ]}
].
```