### PR TITLE
Force the Python thread itself to block SIGBUS

### DIFF
--- a/uhal/python/pkg/uhal/__init__.py
+++ b/uhal/python/pkg/uhal/__init__.py
@@ -12,6 +12,11 @@ except ImportError as e:
     else:
         exec('raise type(e), message.format(e.message), sys.exc_info()[2]')
 
+# The new SigBusGuard functionality for mmap connections requires that
+# all threads block SIGBUS. This includes the main Python thread.
+import signal
+signal.pthread_sigmask(signal.SIG_BLOCK, [signal.SIGBUS])
+
 
 ##################################################
 # Pythonic additions to the ValWord_uint32 API


### PR DESCRIPTION
The new SigBusGuard approach for devices using the mmap protocol requires that all threads block SIGBUS. This includes the Python thread itself.