### PR TITLE
Fix python packaging regression in newer setuptools versions

### DIFF
--- a/uhal/config/setupTemplate.py
+++ b/uhal/config/setupTemplate.py
@@ -39,7 +39,8 @@ setup(name=_name,
       data_files = data_files,
 
       packages = _packages,
-      package_dir = {'' : ''},
+      package_dir = {'' : '.'},
+      zip_safe=False,
       package_data = dict((pkg,['*.so']) for pkg in _packages)
  )
 


### PR DESCRIPTION
This PR fixes the issue described in https://github.com/ipbus/ipbus-software/issues/300

Tested using Python 3.11.3 and Setuptools 65.5.0