### PR TITLE
Use portable Python shebang in ipbus address decoder generator

### DIFF
--- a/uhal/tools/scripts/gen_ipbus_addr_decode
+++ b/uhal/tools/scripts/gen_ipbus_addr_decode
@@ -1,4 +1,4 @@
-#!/usr/libexec/platform-python
+#!/usr/bin/env python
 
 """
 This script automatically generates address select logic for IPbus-based firmware designs.


### PR DESCRIPTION
`/usr/libexec/platform-python` is not provided outside of CentOS (to my knowledge). The "recommended" way of finding the platform python binary (including versions in a venv etc) is via `/usr/bin/env python{2,3}`. I propose using this in the shebang to make adoption on other platforms/distributions easier. 

Edit: additional information can be found in https://peps.python.org/pep-0394/