### PR TITLE
gen_ipbus_addr_decode: If 1 endpoint, select endpoint 0

### DIFF
--- a/uhal/tools/scripts/gen_ipbus_addr_decode
+++ b/uhal/tools/scripts/gen_ipbus_addr_decode
@@ -330,10 +330,8 @@ def main():
         
         # generate vhdl snippet with selection code
         snippet2 = "-- START automatically generated VHDL" + timestamp_suffix + "\n"
-        if numSlaves == 0:
+        if numSlaves <= 1:
             snippet2 += "    sel := ipbus_sel_t(to_unsigned(0, IPBUS_SEL_WIDTH));\n"
-        elif numSlaves == 1:
-            snippet2 += "    sel := ipbus_sel_t(to_unsigned(N_SLAVES, IPBUS_SEL_WIDTH));\n"
         else:
             for n,id,addr_bits,mask_bits in slaves:
                 mask = addr_mask & ~mask_bits


### PR DESCRIPTION
A bugfix following on from the changes in #297 - currently `N_SLAVES` is returned if `numSlaves == 1`, but the 0th slave should be selected instead in that case.