### PR TITLE
gen_ipbus_addr_decode: If 1 endpoint, select endpoint 0 (take 2)

### DIFF
--- a/uhal/tools/scripts/gen_ipbus_addr_decode
+++ b/uhal/tools/scripts/gen_ipbus_addr_decode
@@ -331,7 +331,7 @@ def main():
         # generate vhdl snippet with selection code
         snippet2 = "-- START automatically generated VHDL" + timestamp_suffix + "\n"
         if numSlaves <= 1:
-            snippet2 += "    sel := ipbus_sel_t(to_unsigned(0, IPBUS_SEL_WIDTH));\n"
+            snippet2 += "    sel := ipbus_sel_t(to_unsigned(" + slaveIds[0] + ", IPBUS_SEL_WIDTH));\n"
         else:
             for n,id,addr_bits,mask_bits in slaves:
                 mask = addr_mask & ~mask_bits


### PR DESCRIPTION
Small correction to pull request #303 - use name of the constant, rather than the value.