### PR TITLE
uHAL: Add Python bindings for Python 3.11 on Alma 8

### DIFF
--- a/ci/build-rpm.yml
+++ b/ci/build-rpm.yml
@@ -89,7 +89,7 @@
 
 build:centos7:x86:
   extends: .template_build_rpm_yumrepo:x86
-  image: ${IPBUS_DOCKER_REGISTRY}/centos7/ipbus-sw-dev:2023.06.15__boost1.53.0_pugixml1.8
+  image: ${IPBUS_DOCKER_REGISTRY}/centos7/ipbus-sw-dev:2023.08.30__boost1.53.0_pugixml1.8
   variables:
     OUTPUT_REPO_SUBDIR: centos7/x86_64
     PYTHONS: "python2.7 python3.4 python3.6"
@@ -97,7 +97,7 @@ build:centos7:x86:
 
 build:centos7:arm64:
   extends: .template_build_rpm_yumrepo:arm64
-  image: ${IPBUS_DOCKER_REGISTRY}/centos7/ipbus-sw-dev:2023.06.15__boost1.53.0_pugixml1.8
+  image: ${IPBUS_DOCKER_REGISTRY}/centos7/ipbus-sw-dev:2023.08.30__boost1.53.0_pugixml1.8
   variables:
     OUTPUT_REPO_SUBDIR: centos7/aarch64
     PYTHONS: "python2.7 python3.4 python3.6"
@@ -113,7 +113,7 @@ build:centos7:armv7:
 
 build:alma8:x86:
   extends: .template_build_rpm_yumrepo:x86
-  image: ${IPBUS_DOCKER_REGISTRY}/alma8/ipbus-sw-dev:2023.06.15__boost1.66.0_pugixml1.13
+  image: ${IPBUS_DOCKER_REGISTRY}/alma8/ipbus-sw-dev:2023.08.30__boost1.66.0_pugixml1.13
   variables:
     OUTPUT_REPO_SUBDIR: alma8/x86_64
     PYTHONS: "python3.6 python3.8"
@@ -121,7 +121,7 @@ build:alma8:x86:
 
 build:alma8:arm64:
   extends: .template_build_rpm_yumrepo:arm64
-  image: ${IPBUS_DOCKER_REGISTRY}/alma8/ipbus-sw-dev:2023.06.15__boost1.66.0_pugixml1.13
+  image: ${IPBUS_DOCKER_REGISTRY}/alma8/ipbus-sw-dev:2023.08.30__boost1.66.0_pugixml1.13
   variables:
     OUTPUT_REPO_SUBDIR: alma8/aarch64
     PYTHONS: "python3.6 python3.8"
@@ -130,7 +130,7 @@ build:alma8:arm64:
 
 build:alma9:x86:
   extends: .template_build_rpm_yumrepo:x86
-  image: ${IPBUS_DOCKER_REGISTRY}/alma9/ipbus-sw-dev:2023.06.15__boost1.75.0_pugixml1.13
+  image: ${IPBUS_DOCKER_REGISTRY}/alma9/ipbus-sw-dev:2023.08.30__boost1.75.0_pugixml1.13
   variables:
     OUTPUT_REPO_SUBDIR: alma9/x86_64
     PYTHONS: "python3.9 python3.11"
@@ -138,7 +138,7 @@ build:alma9:x86:
 
 build:alma9:arm64:
   extends: .template_build_rpm_yumrepo:arm64
-  image: ${IPBUS_DOCKER_REGISTRY}/alma9/ipbus-sw-dev:2023.06.15__boost1.75.0_pugixml1.13
+  image: ${IPBUS_DOCKER_REGISTRY}/alma9/ipbus-sw-dev:2023.08.30__boost1.75.0_pugixml1.13
   variables:
     OUTPUT_REPO_SUBDIR: alma9/aarch64
     PYTHONS: "python3.9 python3.11"
@@ -147,7 +147,7 @@ build:alma9:arm64:
 
 build:centos7-gcc8:
   stage: build
-  image: ${IPBUS_DOCKER_REGISTRY}/ipbus-sw-dev-centos7-gcc8:2021-01-26
+  image: ${IPBUS_DOCKER_REGISTRY}/ipbus-sw-dev-centos7-gcc8:2023-08-30
   variables:
     GIT_CLONE_PATH: ${CI_BUILDS_DIR}/${CI_PROJECT_PATH}_____
     OUTPUT_REPO_SUBDIR: centos7_gcc8/x86_64

--- a/ci/build-rpm.yml
+++ b/ci/build-rpm.yml
@@ -118,7 +118,7 @@ build:alma8:x86:
   image: ${IPBUS_DOCKER_REGISTRY}/alma8/ipbus-sw-dev:2023.08.30__boost1.66.0_pugixml1.13
   variables:
     OUTPUT_REPO_SUBDIR: alma8/x86_64
-    PYTHONS: "python3.6 python3.8"
+    PYTHONS: "python3.6 python3.8 python3.11"
     YUMGROUPS_FILE: ci/yum/yumgroups-el8.xml
 
 build:alma8:arm64:
@@ -126,7 +126,7 @@ build:alma8:arm64:
   image: ${IPBUS_DOCKER_REGISTRY}/alma8/ipbus-sw-dev:2023.08.30__boost1.66.0_pugixml1.13
   variables:
     OUTPUT_REPO_SUBDIR: alma8/aarch64
-    PYTHONS: "python3.6 python3.8"
+    PYTHONS: "python3.6 python3.8 python3.11"
     YUMGROUPS_FILE: ci/yum/yumgroups-el8.xml
 
 

--- a/ci/build-rpm.yml
+++ b/ci/build-rpm.yml
@@ -2,6 +2,8 @@
 .template_build_rpm_yumrepo:
   stage: build
   before_script:
+    # Fix for CERN k8s-provisioned shared runners: Limit number of opened file descriptors with ulimit
+    - ulimit -n 1048576
     - export PYTHON=$(echo $PYTHONS | head -n1 | awk '{print $1;}')
     - echo PYTHON=${PYTHON}
     - export REPO_DIR=${CI_PROJECT_DIR}/ci_results/repos/${OUTPUT_REPO_SUBDIR}

--- a/ci/build-simple.yml
+++ b/ci/build-simple.yml
@@ -2,6 +2,8 @@
 .template_build_simple:
   stage: build
   script:
+    # Fix for CERN k8s-provisioned shared runners: Limit number of opened file descriptors with ulimit
+    - ulimit -n 1048576
     - make -k Set=all check-version
     - make -k Set=all
   artifacts:

--- a/ci/build-simple.yml
+++ b/ci/build-simple.yml
@@ -19,7 +19,7 @@
 
 build:centos7:static:
   extends: .template_build_simple
-  image: ${IPBUS_DOCKER_REGISTRY}/ipbus-sw-dev-centos7-static:2021-01-26__boost1.53.0_pugixml1.8
+  image: ${IPBUS_DOCKER_REGISTRY}/ipbus-sw-dev-centos7-static:2023-08-30__boost1.53.0_pugixml1.8
   variables:
     BUILD_STATIC: 1
     BUILD_UHAL_PYTHON: 0

--- a/ci/doxygen.yml
+++ b/ci/doxygen.yml
@@ -1,6 +1,6 @@
 build:doxygen:
   stage: build
-  image: ${IPBUS_DOCKER_REGISTRY}/ipbus-sw-doxygen:2020-06-13__doxygen1.8.18
+  image: ${IPBUS_DOCKER_REGISTRY}/ipbus-sw-doxygen:2023.08.30__doxygen1.9.5
   tags:
     - docker
   script:

--- a/ci/tests.yml
+++ b/ci/tests.yml
@@ -9,6 +9,8 @@ variables:
   stage: test
   dependencies: []
   before_script:
+    # Fix for CERN k8s-provisioned shared runners: Limit number of opened file descriptors with ulimit
+    - ulimit -n 1048576
     - export OUTPUT_PIPELINE_URL=${OUTPUT_ROOT_URL}/commits/${CI_COMMIT_TAG:-${CI_COMMIT_SHA}}/pipeline${CI_PIPELINE_ID}
     - if [ -n "${CI_COMMIT_TAG}" ]; then export OUTPUT_PIPELINE_URL=${OUTPUT_PIPELINE_URL/commits/tags} ; fi
     - sudo cp ci/yum/ipbus-sw-ci.repo /etc/yum.repos.d/ipbus-sw-ci.repo

--- a/ci/tests.yml
+++ b/ci/tests.yml
@@ -21,7 +21,7 @@ variables:
 
 .template_test:centos7:
   extends: .template_test_rpmInstall
-  image: ${IPBUS_DOCKER_REGISTRY}/centos7/ipbus-sw-test:2023.06.15
+  image: ${IPBUS_DOCKER_REGISTRY}/centos7/ipbus-sw-test:2023.08.30
   variables:
     REPO_URL_OS_SUBDIR: centos7
     TEST_SUITE_CONTROLHUB_PATH_ARGUMENT: "-p /opt/cactus/bin"
@@ -56,7 +56,7 @@ variables:
 
 .template_test:alma8:
   extends: .template_test_rpmInstall
-  image: ${IPBUS_DOCKER_REGISTRY}/alma8/ipbus-sw-test:2023.06.15
+  image: ${IPBUS_DOCKER_REGISTRY}/alma8/ipbus-sw-test:2023.08.30
   needs:
     - job: publish:yum:alma8:x86
       artifacts: false
@@ -69,7 +69,7 @@ variables:
 
 .template_test:alma9:
   extends: .template_test_rpmInstall
-  image: ${IPBUS_DOCKER_REGISTRY}/alma9/ipbus-sw-test:2023.06.15
+  image: ${IPBUS_DOCKER_REGISTRY}/alma9/ipbus-sw-test:2023.08.30
   needs:
     - job: publish:yum:alma9:x86
       artifacts: false

--- a/ci/tests.yml
+++ b/ci/tests.yml
@@ -256,6 +256,8 @@ test_python:alma8:
         UHAL_PYTHON_RPM: cactuscore-uhal-python36
       - PYTHON: python3.8
         UHAL_PYTHON_RPM: cactuscore-uhal-python38
+      - PYTHON: python3.11
+        UHAL_PYTHON_RPM: cactuscore-uhal-python311
 
 test_tools:alma8:
   extends: .template_test:alma8

--- a/config/Makefile.macros
+++ b/config/Makefile.macros
@@ -5,6 +5,7 @@ CACTUS_ROOT ?= /opt/cactus
 CACTUS_RPM_ROOT ?= $(BUILD_HOME)
 
 
+SHELL := /bin/bash
 PYTHON ?= python
 CACTUS_PLATFORM=$(shell if [ -f /etc/system-release ]; then cat /etc/system-release; fi)
 CACTUS_OS=unknown.os

--- a/uhal/tools/scripts/gen_ipbus_addr_decode
+++ b/uhal/tools/scripts/gen_ipbus_addr_decode
@@ -330,7 +330,9 @@ def main():
         
         # generate vhdl snippet with selection code
         snippet2 = "-- START automatically generated VHDL" + timestamp_suffix + "\n"
-        if numSlaves <= 1:
+        if numSlaves == 0:
+            snippet2 += "    sel := ipbus_sel_t(to_unsigned(0, IPBUS_SEL_WIDTH));\n"
+        elif numSlaves == 1:
             snippet2 += "    sel := ipbus_sel_t(to_unsigned(" + slaveIds[0] + ", IPBUS_SEL_WIDTH));\n"
         else:
             for n,id,addr_bits,mask_bits in slaves:


### PR DESCRIPTION
Also:
 * Updated CI pipeline to new tag of build images
 * Limit file descriptor for new CERN k8s-provided runners
 * Bugfix to recent `gen_ipbus_addr_decode` changes