### PR TITLE
IPbus-over-mmap client: Add interprocess mutual exclusion

### DIFF
--- a/uhal/uhal/include/uhal/ProtocolMmap.hpp
+++ b/uhal/uhal/include/uhal/ProtocolMmap.hpp
@@ -77,16 +77,6 @@ namespace uhal
   //! Transport protocol to transfer an IPbus buffer via device file, using mmap
   class Mmap : public IPbus< 2 , 0 >
   {
-    public:
-      class PacketFmt {
-      public:
-        PacketFmt(const uint8_t* const, const size_t);
-        PacketFmt(const std::vector< std::pair<const uint8_t*, size_t> >& aData);
-        ~PacketFmt();
-
-        const std::vector< std::pair<const uint8_t*, size_t> > mData;
-      };
-
     private:
       class File {
       public:

--- a/uhal/uhal/include/uhal/ProtocolMmap.hpp
+++ b/uhal/uhal/include/uhal/ProtocolMmap.hpp
@@ -54,6 +54,8 @@
 #include <vector>                          // for vector
 
 #include "uhal/ClientInterface.hpp"
+#include "uhal/detail/RobustSessionMutex.hpp"
+#include "uhal/detail/SharedObject.hpp"
 #include "uhal/log/exception.hpp"
 #include "uhal/ProtocolIPbus.hpp"
 
@@ -95,10 +97,17 @@ namespace uhal
 
         void write(const uint32_t aAddr, const std::vector<std::pair<const uint8_t*, size_t> >& aData);
 
+        bool haveLock() const;
+
+        void lock();
+
+        void unlock();
+
       private:
         std::string mPath;
         int mFd;
         int mFlags;
+        bool mLocked;
         off_t mOffset;
         void* mMmapPtr;
         void* mMmapIOPtr;
@@ -118,6 +127,8 @@ namespace uhal
       Mmap ( const Mmap& aMmap );
 
       Mmap& operator= ( const Mmap& aMmap );
+
+      static std::string getSharedMemName(const std::string& );
 
     public:
       /**
@@ -140,12 +151,10 @@ namespace uhal
       void implementDispatch ( std::shared_ptr< Buffers > aBuffers );
 
       //! Concrete implementation of the synchronization function to block until all buffers have been sent, all replies received and all data validated
-      virtual void Flush( );
-
+      virtual void Flush();
 
       //! Function which tidies up this protocol layer in the event of an exception
       virtual void dispatchExceptionHandler();
-
 
       typedef IPbus< 2 , 0 > InnerProtocol;
 
@@ -166,6 +175,9 @@ namespace uhal
       //! Set up the connection to the device
       void connect();
 
+      //! Set up the connection to the device
+      void connect(detail::ScopedSessionLock& );
+
       //! Close the connection to the device
       void disconnect();
 
@@ -179,18 +191,16 @@ namespace uhal
 
       File mDeviceFile;
 
+      detail::SharedObject<detail::RobustSessionMutex> mIPCMutex;
+      bool mIPCExternalSessionActive;
+      uint64_t mIPCSessionCount;
+
       std::chrono::microseconds mSleepDuration;
 
-      uint32_t mNumberOfPages, mPageSize, mIndexNextPage, mPublishedReplyPageCount, mReadReplyPageCount;
+      uint32_t mNumberOfPages, mMaxInFlight, mPageSize, mMaxPacketSize, mIndexNextPage, mPublishedReplyPageCount, mReadReplyPageCount;
 
       //! The list of buffers still awaiting a reply
       std::deque < std::shared_ptr< Buffers > > mReplyQueue;
-
-      /**
-        A pointer to an exception object for passing exceptions from the worker thread to the main thread.
-        Exceptions must always be created on the heap (i.e. using `new`) and deletion will be handled in the main thread
-      */
-      uhal::exception::exception* mAsynchronousException;
   };
 
 

--- a/uhal/uhal/include/uhal/ProtocolPCIe.hpp
+++ b/uhal/uhal/include/uhal/ProtocolPCIe.hpp
@@ -81,15 +81,6 @@ namespace uhal
   class PCIe : public IPbus< 2 , 0 >
   {
     public:
-      class PacketFmt {
-      public:
-        PacketFmt(const uint8_t* const, const size_t);
-        PacketFmt(const std::vector< std::pair<const uint8_t*, size_t> >& aData);
-        ~PacketFmt();
-
-        const std::vector< std::pair<const uint8_t*, size_t> > mData;
-      };
-
       class File {
       public:
         File(const std::string& aPath, int aFlags);
@@ -263,8 +254,6 @@ namespace uhal
       //! The list of buffers still awaiting a reply
       std::deque < std::shared_ptr< Buffers > > mReplyQueue;
   };
-
-  std::ostream& operator<<(std::ostream& aStream, const PCIe::PacketFmt& aPacket);
 
 }
 

--- a/uhal/uhal/include/uhal/ProtocolPCIe.hpp
+++ b/uhal/uhal/include/uhal/ProtocolPCIe.hpp
@@ -144,7 +144,7 @@ namespace uhal
       void implementDispatch ( std::shared_ptr< Buffers > aBuffers );
 
       //! Concrete implementation of the synchronization function to block until all buffers have been sent, all replies received and all data validated
-      virtual void Flush( );
+      virtual void Flush();
 
       //! Function which tidies up this protocol layer in the event of an exception
       virtual void dispatchExceptionHandler();

--- a/uhal/uhal/include/uhal/detail/PacketFmt.hpp
+++ b/uhal/uhal/include/uhal/detail/PacketFmt.hpp
@@ -1,0 +1,30 @@
+
+#ifndef _uhal_detail_PacketFmt_hpp_
+#define _uhal_detail_PacketFmt_hpp_
+
+
+#include <cstdint>
+#include <iosfwd>
+#include <utility>
+#include <vector>
+
+
+namespace uhal {
+namespace detail {
+
+class PacketFmt {
+public:
+  PacketFmt(const uint8_t* const, const size_t);
+  PacketFmt(const std::vector< std::pair<const uint8_t*, size_t> >& aData);
+  ~PacketFmt();
+
+  const std::vector< std::pair<const uint8_t*, size_t> > mData;
+};
+
+
+std::ostream& operator<<(std::ostream&, const PacketFmt&);
+
+} // end namespace 
+}
+
+#endif

--- a/uhal/uhal/include/uhal/detail/PacketFmt.hpp
+++ b/uhal/uhal/include/uhal/detail/PacketFmt.hpp
@@ -12,6 +12,7 @@
 namespace uhal {
 namespace detail {
 
+//! Class used to display IPbus packet contents in human-readable format (e.g. in log messages)
 class PacketFmt {
 public:
   PacketFmt(const uint8_t* const, const size_t);
@@ -24,7 +25,7 @@ public:
 
 std::ostream& operator<<(std::ostream&, const PacketFmt&);
 
-} // end namespace 
+}
 }
 
 #endif

--- a/uhal/uhal/include/uhal/detail/RobustSessionMutex.hpp
+++ b/uhal/uhal/include/uhal/detail/RobustSessionMutex.hpp
@@ -1,4 +1,7 @@
 
+#ifndef _uhal_detail_RobustSessionMutex_hpp_
+#define _uhal_detail_RobustSessionMutex_hpp_
+
 #include <cstdint>
 #include <mutex>
 #include <pthread.h>
@@ -51,3 +54,5 @@ typedef std::unique_lock<RobustSessionMutex> ScopedSessionLock;
 
 }
 }
+
+#endif

--- a/uhal/uhal/include/uhal/detail/RobustSessionMutex.hpp
+++ b/uhal/uhal/include/uhal/detail/RobustSessionMutex.hpp
@@ -1,0 +1,53 @@
+
+#include <cstdint>
+#include <mutex>
+#include <pthread.h>
+
+#include "uhal/ClientInterface.hpp"
+#include "uhal/log/exception.hpp"
+
+
+namespace uhal {
+namespace detail {
+
+//! Exception class to handle errors from pthread mutex-related functions
+UHAL_DEFINE_DERIVED_EXCEPTION_CLASS ( MutexError , uhal::exception::TransportLayerError , "Exception class to handle errors from pthread mutex-related functions." )
+
+/*!
+ * Mutex with session counter and 'session active' flag. Instantiated in shared memory by
+ * the file-based client classes to prevent multiple clients from communicating with the
+ * IPbus device at the same time, and to enable each client to work out if they were the
+ * most recent client to communicate with the device (by checking whether the session
+ * counter has changed). "Robust" since the robustness flag is set in the pthread mutex,
+ * such that we can detect whether a process died before unlocking it.
+ */
+class RobustSessionMutex {
+public:
+  RobustSessionMutex();
+  ~RobustSessionMutex();
+
+  void lock();
+
+  void unlock();
+
+  uint64_t getCounter() const;
+
+  bool isActive() const;
+
+  void startSession();
+
+  void endSession();
+
+private:
+  RobustSessionMutex(const RobustSessionMutex&);
+
+  pthread_mutex_t mMutex;
+  uint64_t mCount;
+  bool mSessionActive;
+};
+
+
+typedef std::unique_lock<RobustSessionMutex> ScopedSessionLock;
+
+}
+}

--- a/uhal/uhal/include/uhal/detail/SharedObject.hpp
+++ b/uhal/uhal/include/uhal/detail/SharedObject.hpp
@@ -1,0 +1,32 @@
+
+#include <string>
+
+#include <boost/interprocess/managed_shared_memory.hpp>
+
+
+namespace uhal {
+namespace detail {
+
+//! Wrapper for C++ object that's placed in shared memory
+template <class T>
+class SharedObject {
+public:
+
+  SharedObject(const SharedObject<T>&) = delete;
+  SharedObject<T>& operator=(const SharedObject<T>&) = delete;
+
+  SharedObject(const std::string& aName);
+  ~SharedObject();
+
+  T* operator->();
+
+  T& operator*();
+
+private:
+  std::string mName;
+  boost::interprocess::managed_shared_memory mSharedMem;
+  T* mObj;
+};
+
+}
+}

--- a/uhal/uhal/include/uhal/detail/SharedObject.hpp
+++ b/uhal/uhal/include/uhal/detail/SharedObject.hpp
@@ -1,4 +1,7 @@
 
+#ifndef _uhal_detail_SharedObject_hpp_
+#define _uhal_detail_SharedObject_hpp_
+
 #include <string>
 
 #include <boost/interprocess/managed_shared_memory.hpp>
@@ -30,3 +33,5 @@ private:
 
 }
 }
+
+#endif

--- a/uhal/uhal/src/common/ProtocolMmap.cpp
+++ b/uhal/uhal/src/common/ProtocolMmap.cpp
@@ -49,6 +49,7 @@
 #include <fcntl.h>
 #include <iomanip>                                          // for operator<<
 #include <iostream>                                         // for operator<<
+#include <sys/file.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <stdlib.h>                                         // for size_t, free
@@ -242,18 +243,54 @@ void Mmap::File::write(const uint32_t aAddr, const std::vector<std::pair<const u
 }
 
 
+bool Mmap::File::haveLock() const
+{
+  return mLocked;
+}
+
+
+void Mmap::File::lock()
+{
+  if ( flock(mFd, LOCK_EX) == -1 ) {
+    detail::MutexError lExc;
+    log(lExc, "Failed to lock device file ", Quote(mPath), "; errno=", Integer(errno), ", meaning ", Quote (strerror(errno)));
+    throw lExc;
+  }
+  mLocked = true;
+}
+
+
+void Mmap::File::unlock()
+{
+  if ( flock(mFd, LOCK_UN) == -1 ) {
+    log(Warning(), "Failed to unlock device file ", Quote(mPath), "; errno=", Integer(errno), ", meaning ", Quote (strerror(errno)));
+  }
+  else
+    mLocked = false;
+}
+
+
+std::string Mmap::getSharedMemName(const std::string& aPath)
+{
+  std::string lSanitizedPath(aPath);
+  std::replace(lSanitizedPath.begin(), lSanitizedPath.end(), '/', ':');
+
+  return "/uhal::ipbusmmap-2.0::" + lSanitizedPath;
+}
 
 
 Mmap::Mmap ( const std::string& aId, const URI& aUri ) :
   IPbus< 2 , 0 > ( aId , aUri ),
   mConnected(false),
   mDeviceFile(aUri.mHostname, O_RDWR | O_SYNC),
+  mIPCMutex(getSharedMemName(mDeviceFile.getPath())),
   mNumberOfPages(0),
+  mMaxInFlight(0),
   mPageSize(0),
+  mMaxPacketSize(0),
   mIndexNextPage(0),
   mPublishedReplyPageCount(0),
-  mReadReplyPageCount(0),
-  mAsynchronousException ( NULL )
+  mReadReplyPageCount(0)
 {
   mSleepDuration = std::chrono::microseconds(50);
 
@@ -267,6 +304,14 @@ Mmap::Mmap ( const std::string& aId, const URI& aUri ) :
       const size_t lOffset = (lIsHex ? boost::lexical_cast<HexTo<size_t> >(lArg.second) : boost::lexical_cast<size_t>(lArg.second));
       mDeviceFile.setOffset(lOffset);
       log (Notice(), "mmap client with URI ", Quote (uri()), " : Address offset set to ", Integer(lOffset, IntFmt<hex>()));
+    }
+    else if (lArg.first == "max_in_flight") {
+      mMaxInFlight = boost::lexical_cast<size_t>(lArg.second);
+      log (Notice() , "mmap client with URI ", Quote (uri()), " : 'Maximum number of packets in flight' set to ", boost::lexical_cast<size_t>(lArg.second), " by URI 'max_in_flight' attribute");
+    }
+    else if (lArg.first == "max_packet_size") {
+      mMaxPacketSize = boost::lexical_cast<size_t>(lArg.second);
+      log (Notice() , "mmap client with URI ", Quote (uri()), " : 'Maximum packet size (in 32-bit words) set to ", boost::lexical_cast<size_t>(lArg.second), " by URI 'max_packet_size' attribute");
     }
     else {
       log (Warning() , "Unknown attribute ", Quote (lArg.first), " used in URI ", Quote(uri()));
@@ -300,15 +345,21 @@ void Mmap::Flush( )
   while ( !mReplyQueue.empty() )
     read();
 
+  mDeviceFile.unlock();
+
+  detail::ScopedSessionLock lLockGuard(*mIPCMutex);
+  mIPCMutex->endSession();
 }
 
 
 void Mmap::dispatchExceptionHandler()
 {
-  // FIXME: Adapt to PCIe implementation
   log(Notice(), "mmap client ", Quote(id()), " (URI: ", Quote(uri()), ") : closing device files since exception detected");
 
   ClientInterface::returnBufferToPool ( mReplyQueue );
+
+  mDeviceFile.unlock();
+
   disconnect();
 
   InnerProtocol::dispatchExceptionHandler();
@@ -320,7 +371,7 @@ uint32_t Mmap::getMaxSendSize()
   if ( ! mConnected )
     connect();
 
-  return (mPageSize - 1) * 4;
+  return mMaxPacketSize * 4;
 }
 
 
@@ -329,19 +380,35 @@ uint32_t Mmap::getMaxReplySize()
   if ( ! mConnected )
     connect();
 
-  return (mPageSize - 1) * 4;
+  return mMaxPacketSize * 4;
 }
 
 
 void Mmap::connect()
 {
+  detail::ScopedSessionLock lLockGuard(*mIPCMutex);
+  connect(lLockGuard);
+}
+
+
+void Mmap::connect(detail::ScopedSessionLock& aGuard)
+{
+  // Read current value of session counter when reading status info from FPGA
+  // (So that can check whether this info is up-to-date later on, when sending next request packet)
+  mIPCExternalSessionActive = mIPCMutex->isActive() and (not mDeviceFile.haveLock());
+  mIPCSessionCount = mIPCMutex->getCounter();
+
   log ( Debug() , "mmap client is opening device file " , Quote ( mDeviceFile.getPath() ) );
   std::vector<uint32_t> lValues;
   mDeviceFile.read(0x0, 4, lValues);
   log (Info(), "Read status info from addr 0 (", Integer(lValues.at(0)), ", ", Integer(lValues.at(1)), ", ", Integer(lValues.at(2)), ", ", Integer(lValues.at(3)), "): ", detail::PacketFmt((const uint8_t*)lValues.data(), 4 * lValues.size()));
 
   mNumberOfPages = lValues.at(0);
+  if ( (mMaxInFlight == 0) or (mMaxInFlight > mNumberOfPages) )
+    mMaxInFlight = mNumberOfPages;
   mPageSize = std::min(uint32_t(4096), lValues.at(1));
+  if ( (mMaxPacketSize == 0) or (mMaxPacketSize >= mPageSize) )
+    mMaxPacketSize = mPageSize - 1;
   mIndexNextPage = lValues.at(2);
   mPublishedReplyPageCount = lValues.at(3);
   mReadReplyPageCount = mPublishedReplyPageCount;
@@ -372,14 +439,29 @@ void Mmap::disconnect()
 
 void Mmap::write(const std::shared_ptr<Buffers>& aBuffers)
 {
+  if (not mDeviceFile.haveLock()) {
+    mDeviceFile.lock();
+
+    detail::ScopedSessionLock lGuard(*mIPCMutex);
+    mIPCMutex->startSession();
+    mIPCSessionCount++;
+
+    // If these two numbers don't match, another client/process has sent packets
+    // more recently than this client has, so must re-read status info
+    if (mIPCExternalSessionActive or (mIPCMutex->getCounter() != mIPCSessionCount)) {
+      connect(lGuard);
+    }
+  }
+
   log (Info(), "mmap client ", Quote(id()), " (URI: ", Quote(uri()), ") : writing ", Integer(aBuffers->sendCounter() / 4), "-word packet to page ", Integer(mIndexNextPage), " in ", Quote(mDeviceFile.getPath()));
 
   const uint32_t lHeaderWord = (0x10000 | (((aBuffers->sendCounter() / 4) - 1) & 0xFFFF));
   std::vector<std::pair<const uint8_t*, size_t> > lDataToWrite;
   lDataToWrite.push_back( std::make_pair(reinterpret_cast<const uint8_t*>(&lHeaderWord), sizeof lHeaderWord) );
   lDataToWrite.push_back( std::make_pair(aBuffers->getSendBuffer(), aBuffers->sendCounter()) );
-  mDeviceFile.write(mIndexNextPage * 4 * mPageSize, lDataToWrite);
 
+  detail::ScopedSessionLock lGuard(*mIPCMutex);
+  mDeviceFile.write(mIndexNextPage * 4 * mPageSize, lDataToWrite);
   log (Debug(), "Wrote " , Integer((aBuffers->sendCounter() / 4) + 1), " 32-bit words at address " , Integer(mIndexNextPage * 4 * mPageSize), " ... ", detail::PacketFmt(lDataToWrite));
 
   mIndexNextPage = (mIndexNextPage + 1) % mNumberOfPages;
@@ -396,9 +478,10 @@ void Mmap::read()
   {
     uint32_t lHwPublishedPageCount = 0x0;
 
+    std::vector<uint32_t> lValues;
     while ( true ) {
-      std::vector<uint32_t> lValues;
       // FIXME : Improve by simply adding dmaWrite method that takes uint32_t ref as argument (or returns uint32_t)
+      detail::ScopedSessionLock lGuard(*mIPCMutex);
       mDeviceFile.read(0, 4, lValues);
       lHwPublishedPageCount = lValues.at(3);
       log (Info(), "Read status info from addr 0 (", Integer(lValues.at(0)), ", ", Integer(lValues.at(1)), ", ", Integer(lValues.at(2)), ", ", Integer(lValues.at(3)), "): ", detail::PacketFmt((const uint8_t*)lValues.data(), 4 * lValues.size()));
@@ -418,6 +501,7 @@ void Mmap::read()
       log(Debug(), "mmap client ", Quote(id()), " (URI: ", Quote(uri()), ") : Trying to read page index ", Integer(lPageIndexToRead), " = count ", Integer(mReadReplyPageCount+1), "; published page count is ", Integer(lHwPublishedPageCount), "; sleeping for ", mSleepDuration.count(), "us");
       if (mSleepDuration > std::chrono::microseconds(0))
         std::this_thread::sleep_for( mSleepDuration );
+      lValues.clear();
     }
 
     log(Info(), "mmap client ", Quote(id()), " (URI: ", Quote(uri()), ") : Reading page ", Integer(lPageIndexToRead), " (published count ", Integer(lHwPublishedPageCount), ", surpasses required, ", Integer(mReadReplyPageCount + 1), ")");
@@ -432,7 +516,9 @@ void Mmap::read()
   lNrWordsToRead += 1;
  
   std::vector<uint32_t> lPageContents;
+  detail::ScopedSessionLock lGuard(*mIPCMutex);
   mDeviceFile.read(4 + lPageIndexToRead * mPageSize, lNrWordsToRead , lPageContents);
+  lGuard.unlock();
   log (Debug(), "Read " , Integer(lNrWordsToRead), " 32-bit words from address " , Integer(16 + lPageIndexToRead * 4 * mPageSize), " ... ", detail::PacketFmt((const uint8_t*)lPageContents.data(), 4 * lPageContents.size()));
 
   // PART 2 : Transfer to reply buffer
@@ -455,24 +541,20 @@ void Mmap::read()
 
 
   // PART 3 : Validate the packet contents
-  mAsynchronousException = NULL;
+  uhal::exception::exception* lExc = NULL;
   try
   {
-    if ( uhal::exception::exception* lExc = ClientInterface::validate ( lBuffers ) ) //Control of the pointer has been passed back to the client interface
-    {
-      mAsynchronousException = lExc;
-    }
+    lExc = ClientInterface::validate ( lBuffers );
   }
   catch ( exception::exception& aExc )
   {
-    mAsynchronousException = new exception::ValidationError ();
-    log ( *mAsynchronousException , "Exception caught during reply validation for mmap device with URI " , Quote ( this->uri() ) , "; what returned: " , Quote ( aExc.what() ) );
+    exception::ValidationError lExc2;
+    log ( lExc2 , "Exception caught during reply validation for mmap device with URI " , Quote ( this->uri() ) , "; what returned: " , Quote ( aExc.what() ) );
+    throw lExc2;
   }
 
-  if ( mAsynchronousException )
-  {
-    mAsynchronousException->throwAsDerivedType();
-  }
+  if (lExc != NULL)
+    lExc->throwAsDerivedType();
 }
 
 

--- a/uhal/uhal/src/common/ProtocolPCIe.cpp
+++ b/uhal/uhal/src/common/ProtocolPCIe.cpp
@@ -285,7 +285,7 @@ bool PCIe::File::haveLock() const
 void PCIe::File::lock()
 {
   if ( flock(mFd, LOCK_EX) == -1 ) {
-    exception::MutexError lExc;
+    detail::MutexError lExc;
     log(lExc, "Failed to lock device file ", Quote(mPath), "; errno=", Integer(errno), ", meaning ", Quote (strerror(errno)));
     throw lExc;
   }
@@ -301,127 +301,6 @@ void PCIe::File::unlock()
   else
     mLocked = false;
 }
-
-
-
-
-PCIe::RobustMutex::RobustMutex() :
-  mCount(0),
-  mSessionActive(false)
-{
-  pthread_mutexattr_t lAttr;
-
-  int s = pthread_mutexattr_init(&lAttr);
-  if (s != 0) {
-    exception::MutexError lExc;
-    log(lExc, "Error code ", Integer(s), " (", strerror(s), ") returned in mutex attr initialisation");
-    throw lExc;
-  }
-
-  s = pthread_mutexattr_setpshared(&lAttr, PTHREAD_PROCESS_SHARED);
-  if (s != 0) {
-    exception::MutexError lExc;
-    log(lExc, "Error code ", Integer(s), " (", strerror(s), ") returned by pthread_mutexattr_setpshared");
-    throw lExc;
-  }
-
-  s = pthread_mutexattr_setrobust(&lAttr, PTHREAD_MUTEX_ROBUST);
-  if (s != 0) {
-    exception::MutexError lExc;
-    log(lExc, "Error code ", Integer(s), " (", strerror(s), ") returned by pthread_mutexattr_setrobust");
-    throw lExc;
-  }
-
-  s = pthread_mutex_init(&mMutex, &lAttr);
-  if (s != 0) {
-    exception::MutexError lExc;
-    log(lExc, "Error code ", Integer(s), " (", strerror(s), ") returned in mutex initialisation");
-    throw lExc;
-  }
-}
-
-
-PCIe::RobustMutex::~RobustMutex()
-{
-}
-
-
-void PCIe::RobustMutex::lock()
-{
-  int s = pthread_mutex_lock(&mMutex);
-  bool lLastOwnerDied = (s == EOWNERDEAD);
-  if (lLastOwnerDied)
-    s = pthread_mutex_consistent(&mMutex);
-
-  if (s != 0) {
-    exception::MutexError lExc;
-    log(lExc, "Error code ", Integer(s), " (", strerror(s), ") returned when ", lLastOwnerDied ? "making mutex state consistent" : "locking mutex");
-    throw lExc;
-  }
-}
-
-
-void PCIe::RobustMutex::unlock()
-{
-  int s = pthread_mutex_unlock(&mMutex);
-  if (s != 0)
-    log(Error(), "Error code ", Integer(s), " (", strerror(s), ") returned when unlocking mutex");
-}
-
-
-uint64_t PCIe::RobustMutex::getCounter() const
-{
-  return mCount;
-}
-
-
-bool PCIe::RobustMutex::isActive() const
-{
-  return mSessionActive;
-}
-
-
-void PCIe::RobustMutex::startSession()
-{
-  mCount++;
-  mSessionActive = true;
-}
-
-void PCIe::RobustMutex::endSession()
-{
-  mSessionActive = false;
-}
-
-
-
-
-template <class T>
-PCIe::SharedObject<T>::SharedObject(const std::string& aName) :
-  mName(aName),
-  mSharedMem(boost::interprocess::open_or_create, aName.c_str(), 1024, 0x0, boost::interprocess::permissions(0666)),
-  mObj(mSharedMem.find_or_construct<T>(boost::interprocess::unique_instance)())
-{
-}
-
-template <class T>
-PCIe::SharedObject<T>::~SharedObject()
-{
-  // boost::interprocess::shared_memory_object::remove(mName.c_str());
-}
-
-template <class T>
-T* PCIe::SharedObject<T>::operator->()
-{
-  return mObj;
-}
-
-template <class T>
-T& PCIe::SharedObject<T>::operator*()
-{
-  return *mObj;
-}
-
-
 
 
 std::string PCIe::getSharedMemName(const std::string& aPath)
@@ -524,7 +403,7 @@ void PCIe::Flush( )
 
   mDeviceFileHostToFPGA.unlock();
 
-  IPCScopedLock_t lLockGuard(*mIPCMutex);
+  detail::ScopedSessionLock lLockGuard(*mIPCMutex);
   mIPCMutex->endSession();
 }
 
@@ -563,12 +442,12 @@ uint32_t PCIe::getMaxReplySize()
 
 void PCIe::connect()
 {
-  IPCScopedLock_t lLockGuard(*mIPCMutex);
+  detail::ScopedSessionLock lLockGuard(*mIPCMutex);
   connect(lLockGuard);
 }
 
 
-void PCIe::connect(IPCScopedLock_t& aGuard)
+void PCIe::connect(detail::ScopedSessionLock& aGuard)
 {
   // Read current value of session counter when reading status info from FPGA
   // (So that can check whether this info is up-to-date later on, when sending next request packet)
@@ -633,7 +512,7 @@ void PCIe::write(const std::shared_ptr<Buffers>& aBuffers)
   if (not mDeviceFileHostToFPGA.haveLock()) {
     mDeviceFileHostToFPGA.lock();
 
-    IPCScopedLock_t lGuard(*mIPCMutex);
+    detail::ScopedSessionLock lGuard(*mIPCMutex);
     mIPCMutex->startSession();
     mIPCSessionCount++;
 
@@ -651,7 +530,7 @@ void PCIe::write(const std::shared_ptr<Buffers>& aBuffers)
   lDataToWrite.push_back( std::make_pair(reinterpret_cast<const uint8_t*>(&lHeaderWord), sizeof lHeaderWord) );
   lDataToWrite.push_back( std::make_pair(aBuffers->getSendBuffer(), aBuffers->sendCounter()) );
 
-  IPCScopedLock_t lGuard(*mIPCMutex);
+  detail::ScopedSessionLock lGuard(*mIPCMutex);
   mDeviceFileHostToFPGA.write(mIndexNextPage * 4 * mPageSize, lDataToWrite);
   log (Debug(), "Wrote " , Integer((aBuffers->sendCounter() / 4) + 1), " 32-bit words at address " , Integer(mIndexNextPage * 4 * mPageSize), " ... ", detail::PacketFmt(lDataToWrite));
 
@@ -699,7 +578,7 @@ void PCIe::read()
       std::vector<uint32_t> lValues;
       while ( true ) {
         // FIXME : Improve by simply adding fileWrite method that takes uint32_t ref as argument (or returns uint32_t)
-        IPCScopedLock_t lGuard(*mIPCMutex);
+        detail::ScopedSessionLock lGuard(*mIPCMutex);
         mDeviceFileFPGAToHost.read(0, (mXdma7seriesWorkaround ? 8 : 4), lValues);
         lHwPublishedPageCount = lValues.at(3);
         log (Debug(), "Read status info from addr 0 (", Integer(lValues.at(0)), ", ", Integer(lValues.at(1)), ", ", Integer(lValues.at(2)), ", ", Integer(lValues.at(3)), "): ", detail::PacketFmt((const uint8_t*)lValues.data(), 4 * lValues.size()));
@@ -737,7 +616,7 @@ void PCIe::read()
   lNrWordsToRead += 1;
  
   std::vector<uint32_t> lPageContents;
-  IPCScopedLock_t lGuard(*mIPCMutex);
+  detail::ScopedSessionLock lGuard(*mIPCMutex);
   mDeviceFileFPGAToHost.read(4 + lPageIndexToRead * mPageSize, lNrWordsToRead , lPageContents);
   lGuard.unlock();
   log (Debug(), "Read " , Integer(lNrWordsToRead), " 32-bit words from address " , Integer(16 + lPageIndexToRead * 4 * mPageSize), " ... ", detail::PacketFmt((const uint8_t*)lPageContents.data(), 4 * lPageContents.size()));

--- a/uhal/uhal/src/common/ProtocolPCIe.cpp
+++ b/uhal/uhal/src/common/ProtocolPCIe.cpp
@@ -460,7 +460,7 @@ void PCIe::connect(detail::ScopedSessionLock& aGuard)
   std::vector<uint32_t> lValues;
   mDeviceFileFPGAToHost.read(0x0, 4, lValues);
   aGuard.unlock();
-  log ( Debug(), "Read status info (", Integer(lValues.at(0)), ", ", Integer(lValues.at(1)), ", ", Integer(lValues.at(2)), ", ", Integer(lValues.at(3)), "): ", detail::PacketFmt((const uint8_t*)lValues.data(), 4 * lValues.size()));
+  log ( Debug(), "Read status info from addr 0 (", Integer(lValues.at(0)), ", ", Integer(lValues.at(1)), ", ", Integer(lValues.at(2)), ", ", Integer(lValues.at(3)), "): ", detail::PacketFmt((const uint8_t*)lValues.data(), 4 * lValues.size()));
 
   mNumberOfPages = lValues.at(0);
   if ( (mMaxInFlight == 0) or (mMaxInFlight > mNumberOfPages) )

--- a/uhal/uhal/src/common/detail/PacketFmt.cpp
+++ b/uhal/uhal/src/common/detail/PacketFmt.cpp
@@ -1,0 +1,44 @@
+
+#include "uhal/detail/PacketFmt.hpp"
+
+
+#include <iomanip>
+#include <iostream>
+
+
+namespace uhal {
+namespace detail {
+
+PacketFmt::PacketFmt(const uint8_t* const aPtr, const size_t aNrBytes) :
+  mData(1, std::pair<const uint8_t*, size_t>(aPtr, aNrBytes))
+{}
+
+
+PacketFmt::PacketFmt(const std::vector< std::pair<const uint8_t*, size_t> >& aData) :
+  mData(aData)
+{}
+
+
+PacketFmt::~PacketFmt()
+{}
+
+
+std::ostream& operator<<(std::ostream& aStream, const PacketFmt& aPacket)
+{
+  std::ios::fmtflags lOrigFlags( aStream.flags() );
+
+  size_t lNrBytesWritten = 0;
+  for (size_t i = 0; i < aPacket.mData.size(); i++) {
+    for (const uint8_t* lPtr = aPacket.mData.at(i).first; lPtr != (aPacket.mData.at(i).first + aPacket.mData.at(i).second); lPtr++, lNrBytesWritten++) {
+      if ((lNrBytesWritten & 3) == 0)
+        aStream << std::endl << "   @ " << std::setw(3) << std::dec << (lNrBytesWritten >> 2) << " :  x";
+      aStream << std::setw(2) << std::hex << uint16_t(*lPtr) << " ";
+    }
+  }
+
+  aStream.flags( lOrigFlags );
+  return aStream;
+}
+
+}
+}

--- a/uhal/uhal/src/common/detail/RobustSessionMutex.cpp
+++ b/uhal/uhal/src/common/detail/RobustSessionMutex.cpp
@@ -1,0 +1,101 @@
+
+#include "uhal/detail/RobustSessionMutex.hpp"
+
+
+#include <string.h>
+
+#include "uhal/log/log.hpp"
+
+
+namespace uhal {
+namespace detail {
+
+RobustSessionMutex::RobustSessionMutex() :
+  mCount(0),
+  mSessionActive(false)
+{
+  pthread_mutexattr_t lAttr;
+
+  int s = pthread_mutexattr_init(&lAttr);
+  if (s != 0) {
+    MutexError lExc;
+    log(lExc, "Error code ", Integer(s), " (", strerror(s), ") returned in mutex attr initialisation");
+    throw lExc;
+  }
+
+  s = pthread_mutexattr_setpshared(&lAttr, PTHREAD_PROCESS_SHARED);
+  if (s != 0) {
+    MutexError lExc;
+    log(lExc, "Error code ", Integer(s), " (", strerror(s), ") returned by pthread_mutexattr_setpshared");
+    throw lExc;
+  }
+
+  s = pthread_mutexattr_setrobust(&lAttr, PTHREAD_MUTEX_ROBUST);
+  if (s != 0) {
+    MutexError lExc;
+    log(lExc, "Error code ", Integer(s), " (", strerror(s), ") returned by pthread_mutexattr_setrobust");
+    throw lExc;
+  }
+
+  s = pthread_mutex_init(&mMutex, &lAttr);
+  if (s != 0) {
+    MutexError lExc;
+    log(lExc, "Error code ", Integer(s), " (", strerror(s), ") returned in mutex initialisation");
+    throw lExc;
+  }
+}
+
+
+RobustSessionMutex::~RobustSessionMutex()
+{
+}
+
+
+void RobustSessionMutex::lock()
+{
+  int s = pthread_mutex_lock(&mMutex);
+  bool lLastOwnerDied = (s == EOWNERDEAD);
+  if (lLastOwnerDied)
+    s = pthread_mutex_consistent(&mMutex);
+
+  if (s != 0) {
+    MutexError lExc;
+    log(lExc, "Error code ", Integer(s), " (", strerror(s), ") returned when ", lLastOwnerDied ? "making mutex state consistent" : "locking mutex");
+    throw lExc;
+  }
+}
+
+
+void RobustSessionMutex::unlock()
+{
+  int s = pthread_mutex_unlock(&mMutex);
+  if (s != 0)
+    log(Error(), "Error code ", Integer(s), " (", strerror(s), ") returned when unlocking mutex");
+}
+
+
+uint64_t RobustSessionMutex::getCounter() const
+{
+  return mCount;
+}
+
+
+bool RobustSessionMutex::isActive() const
+{
+  return mSessionActive;
+}
+
+
+void RobustSessionMutex::startSession()
+{
+  mCount++;
+  mSessionActive = true;
+}
+
+void RobustSessionMutex::endSession()
+{
+  mSessionActive = false;
+}
+
+}
+}

--- a/uhal/uhal/src/common/detail/SharedObject.cpp
+++ b/uhal/uhal/src/common/detail/SharedObject.cpp
@@ -1,0 +1,41 @@
+
+#include "uhal/detail/SharedObject.hpp"
+
+
+#include "uhal/detail/RobustSessionMutex.hpp"
+
+
+namespace uhal {
+namespace detail {
+
+template <class T>
+SharedObject<T>::SharedObject(const std::string& aName) :
+  mName(aName),
+  mSharedMem(boost::interprocess::open_or_create, aName.c_str(), 1024, 0x0, boost::interprocess::permissions(0666)),
+  mObj(mSharedMem.find_or_construct<T>(boost::interprocess::unique_instance)())
+{
+}
+
+template <class T>
+SharedObject<T>::~SharedObject()
+{
+  // boost::interprocess::shared_memory_object::remove(mName.c_str());
+}
+
+template <class T>
+T* SharedObject<T>::operator->()
+{
+  return mObj;
+}
+
+template <class T>
+T& SharedObject<T>::operator*()
+{
+  return *mObj;
+}
+
+
+template class SharedObject<RobustSessionMutex>;
+
+}
+}


### PR DESCRIPTION
Same implementation as in the IPbus-over-PCIe client; utility classes moved to separate files to avoid code duplication. 