### PR TITLE
Boost asio 1.87

### DIFF
--- a/uhal/tests/include/uhal/tests/TCPDummyHardware.hpp
+++ b/uhal/tests/include/uhal/tests/TCPDummyHardware.hpp
@@ -84,8 +84,8 @@ namespace uhal {
 
         void handle_read_chunk_payload(const boost::system::error_code& ec, std::size_t length);
 
-        //! The BOOST ASIO io_service used by the TCP server
-        boost::asio::io_service mIOservice;
+        //! The BOOST ASIO io_cpmtext used by the TCP server
+        boost::asio::io_context mIOservice;
         //! The TCP acceptor which opens the TCP port and handles the connection
         boost::asio::ip::tcp::acceptor mAcceptor;
         //! The socket opened by the TCP server 

--- a/uhal/tests/include/uhal/tests/UDPDummyHardware.hpp
+++ b/uhal/tests/include/uhal/tests/UDPDummyHardware.hpp
@@ -76,8 +76,8 @@ namespace uhal {
     private:
       void handle_receive(const boost::system::error_code& ec, std::size_t length);
 
-      //! The BOOST ASIO io_service used by the UDP server
-      boost::asio::io_service mIOservice;
+      //! The BOOST ASIO io_context used by the UDP server
+      boost::asio::io_context mIOservice;
       //! The socket opened by the UDP server 
       boost::asio::ip::udp::socket mSocket;
       //! The endpoint which sent the UDP datagram

--- a/uhal/tests/src/common/TCPDummyHardware.cpp
+++ b/uhal/tests/src/common/TCPDummyHardware.cpp
@@ -13,7 +13,7 @@ void uhal::tests::TCPDummyHardware< IPbus_major , IPbus_minor >::run()
     mAcceptor.async_accept ( mSocket, [&] (const boost::system::error_code& e) {this->handle_accept(e);} );
 
     mIOservice.run();  
-    mIOservice.restart()();
+    mIOservice.restart();
 }
 
 

--- a/uhal/tests/src/common/TCPDummyHardware.cpp
+++ b/uhal/tests/src/common/TCPDummyHardware.cpp
@@ -13,7 +13,7 @@ void uhal::tests::TCPDummyHardware< IPbus_major , IPbus_minor >::run()
     mAcceptor.async_accept ( mSocket, [&] (const boost::system::error_code& e) {this->handle_accept(e);} );
 
     mIOservice.run();  
-    mIOservice.reset();
+    mIOservice.restart()();
 }
 
 

--- a/uhal/uhal/include/uhal/ProtocolTCP.hpp
+++ b/uhal/uhal/include/uhal/ProtocolTCP.hpp
@@ -194,7 +194,7 @@ namespace uhal
       boost::asio::ip::tcp::socket mSocket;
 
       //! A shared pointer to a boost::asio tcp endpoint - used by the delayed (open-on-first-use) connect
-      boost::asio::ip::tcp::resolver::iterator mEndpoint;
+      boost::asio::ip::tcp::resolver::results_type mEndpoint;
 
       //! The mechanism for providing the time-out
       boost::asio::deadline_timer mDeadlineTimer;

--- a/uhal/uhal/include/uhal/ProtocolTCP.hpp
+++ b/uhal/uhal/include/uhal/ProtocolTCP.hpp
@@ -50,7 +50,8 @@
 #include <thread>
 #include <vector>
 
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/executor_work_guard.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/deadline_timer.hpp>
 
@@ -186,8 +187,8 @@ namespace uhal
       //! The maximum UDP payload size (in bytes)
       size_t mMaxPayloadSize;
 
-      //! The boost::asio::io_service used to create the connections
-      boost::asio::io_service mIOservice;
+      //! The boost::asio::io_context used to create the connections
+      boost::asio::io_context mIOservice;
 
       //! A shared pointer to a boost::asio tcp socket through which the operation will be performed
       boost::asio::ip::tcp::socket mSocket;
@@ -198,8 +199,8 @@ namespace uhal
       //! The mechanism for providing the time-out
       boost::asio::deadline_timer mDeadlineTimer;
 
-      /// Needed when multi-threading to stop the boost::asio::io_service thinking it has nothing to do and so close the socket
-      boost::asio::io_service::work mIOserviceWork;
+      /// Needed when multi-threading to stop the boost::asio::io_context thinking it has nothing to do and so close the socket
+      boost::asio::executor_work_guard<boost::asio::io_context::executor_type> mIOserviceWork;
 
       //! The Worker thread in Multi-threaded mode
       std::thread mDispatchThread;

--- a/uhal/uhal/include/uhal/ProtocolUDP.hpp
+++ b/uhal/uhal/include/uhal/ProtocolUDP.hpp
@@ -49,7 +49,8 @@
 #include <thread>
 #include <vector>
 
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/executor_work_guard.hpp>
 #include <boost/asio/ip/udp.hpp>
 #include <boost/asio/deadline_timer.hpp>
 
@@ -182,8 +183,8 @@ namespace uhal
       //! The maximum UDP payload size (in bytes)
       size_t mMaxPayloadSize;
 
-      //! The boost::asio::io_service used to create the connections
-      boost::asio::io_service mIOservice;
+      //! The boost::asio::io_context used to create the connections
+      boost::asio::io_context mIOservice;
 
       //! A shared pointer to a boost::asio udp socket through which the operation will be performed
       boost::asio::ip::udp::socket mSocket;
@@ -201,8 +202,8 @@ namespace uhal
       */
       std::vector<uint8_t> mReplyMemory;
 
-      //! Needed when multi-threading to stop the boost::asio::io_service thinking it has nothing to do and so close the socket
-      boost::asio::io_service::work mIOserviceWork;
+      //! Needed when multi-threading to stop the boost::asio::context thinking it has nothing to do and so close the socket
+      boost::asio::executor_work_guard<boost::asio::io_context::executor_type> mIOserviceWork;
 
       //! The Worker thread in Multi-threaded mode
       std::thread mDispatchThread;

--- a/uhal/uhal/src/common/ProtocolControlHub.cpp
+++ b/uhal/uhal/src/common/ProtocolControlHub.cpp
@@ -94,7 +94,7 @@ namespace uhal
 
     try
     {
-      boost::asio::io_service lService;
+      boost::asio::io_context lService;
       boost::asio::ip::udp::endpoint lEndpoint (
         *boost::asio::ip::udp::resolver::iterator (
           boost::asio::ip::udp::resolver ( lService ).resolve (

--- a/uhal/uhal/src/common/ProtocolControlHub.cpp
+++ b/uhal/uhal/src/common/ProtocolControlHub.cpp
@@ -96,11 +96,9 @@ namespace uhal
     {
       boost::asio::io_context lService;
       boost::asio::ip::udp::endpoint lEndpoint (
-        *boost::asio::ip::udp::resolver::iterator (
-          boost::asio::ip::udp::resolver ( lService ).resolve (
-            boost::asio::ip::udp::resolver::query ( boost::asio::ip::udp::v4() , lIP.first , lIP.second )
-          )
-        )
+        *boost::asio::ip::udp::resolver ( lService ).resolve (
+            boost::asio::ip::udp::v4() , lIP.first , lIP.second
+         ).begin()
       );
       lAddr = lEndpoint.address().to_string();
       lPort = lEndpoint.port();

--- a/uhal/uhal/src/common/ProtocolTCP.cpp
+++ b/uhal/uhal/src/common/ProtocolTCP.cpp
@@ -66,7 +66,7 @@ namespace uhal
     mSocket ( mIOservice ),
     mEndpoint ( boost::asio::ip::tcp::resolver ( mIOservice ).resolve ( boost::asio::ip::tcp::resolver::query ( aUri.mHostname , aUri.mPort ) ) ),
     mDeadlineTimer ( mIOservice ),
-    mIOserviceWork ( mIOservice ),
+    mIOserviceWork ( mIOservice.get_executor() ),
     mDispatchThread ( [this] () { mIOservice.run(); } ),
     mDispatchQueue(),
     mReplyQueue(),

--- a/uhal/uhal/src/common/ProtocolTCP.cpp
+++ b/uhal/uhal/src/common/ProtocolTCP.cpp
@@ -64,7 +64,7 @@ namespace uhal
     mMaxPayloadSize (350 * 4),
     mIOservice ( ),
     mSocket ( mIOservice ),
-    mEndpoint ( boost::asio::ip::tcp::resolver ( mIOservice ).resolve ( boost::asio::ip::tcp::resolver::query ( aUri.mHostname , aUri.mPort ) ) ),
+    mEndpoint ( boost::asio::ip::tcp::resolver ( mIOservice ).resolve ( aUri.mHostname , aUri.mPort ) ),
     mDeadlineTimer ( mIOservice ),
     mIOserviceWork ( mIOservice.get_executor() ),
     mDispatchThread ( [this] () { mIOservice.run(); } ),
@@ -160,7 +160,7 @@ namespace uhal
   template < typename InnerProtocol , std::size_t nr_buffers_per_send >
   void TCP< InnerProtocol , nr_buffers_per_send >::connect()
   {
-    log ( Info() , "Attempting to create TCP connection to '" , mEndpoint->host_name() , "' port " , mEndpoint->service_name() , "." );
+      log ( Info() , "Attempting to create TCP connection to '" , mEndpoint.begin()->host_name() , "' port " , mEndpoint.begin()->service_name() , "." );
     mDeadlineTimer.expires_from_now ( this->getBoostTimeoutPeriod() );
     boost::system::error_code lErrorCode;
     boost::asio::connect ( mSocket , mEndpoint , lErrorCode );

--- a/uhal/uhal/src/common/ProtocolUDP.cpp
+++ b/uhal/uhal/src/common/ProtocolUDP.cpp
@@ -61,7 +61,7 @@ namespace uhal
     mMaxPayloadSize (350 * 4),
     mIOservice ( ),
     mSocket ( mIOservice , boost::asio::ip::udp::endpoint ( boost::asio::ip::udp::v4(), 0 ) ),
-    mEndpoint ( *boost::asio::ip::udp::resolver ( mIOservice ).resolve ( boost::asio::ip::udp::resolver::query ( boost::asio::ip::udp::v4() , aUri.mHostname , aUri.mPort ) ) ),
+    mEndpoint ( *boost::asio::ip::udp::resolver ( mIOservice ).resolve ( boost::asio::ip::udp::v4() , aUri.mHostname , aUri.mPort ) ),
     mDeadlineTimer ( mIOservice ),
     mReplyMemory ( ),
     mIOserviceWork ( mIOservice.get_executor() ),
@@ -195,7 +195,7 @@ namespace uhal
       mDeadlineTimer.expires_from_now ( this->getBoostTimeoutPeriod() );
     }
 
-    mSocket.async_send_to ( lAsioSendBuffer , mEndpoint , [&] (const boost::system::error_code& e, std::size_t n) { this->write_callback(e, n); });
+    mSocket.async_send_to ( lAsioSendBuffer , *mEndpoint.begin() , [&] (const boost::system::error_code& e, std::size_t n) { this->write_callback(e, n); });
     mPacketsInFlight++;
   }
 

--- a/uhal/uhal/src/common/ProtocolUDP.cpp
+++ b/uhal/uhal/src/common/ProtocolUDP.cpp
@@ -61,7 +61,7 @@ namespace uhal
     mMaxPayloadSize (350 * 4),
     mIOservice ( ),
     mSocket ( mIOservice , boost::asio::ip::udp::endpoint ( boost::asio::ip::udp::v4(), 0 ) ),
-    mEndpoint ( *boost::asio::ip::udp::resolver ( mIOservice ).resolve ( boost::asio::ip::udp::v4() , aUri.mHostname , aUri.mPort ) ),
+    mEndpoint ( *boost::asio::ip::udp::resolver ( mIOservice ).resolve ( boost::asio::ip::udp::v4() , aUri.mHostname , aUri.mPort ).begin() ),
     mDeadlineTimer ( mIOservice ),
     mReplyMemory ( ),
     mIOserviceWork ( mIOservice.get_executor() ),
@@ -195,7 +195,7 @@ namespace uhal
       mDeadlineTimer.expires_from_now ( this->getBoostTimeoutPeriod() );
     }
 
-    mSocket.async_send_to ( lAsioSendBuffer , *mEndpoint.begin() , [&] (const boost::system::error_code& e, std::size_t n) { this->write_callback(e, n); });
+    mSocket.async_send_to ( lAsioSendBuffer , mEndpoint , [&] (const boost::system::error_code& e, std::size_t n) { this->write_callback(e, n); });
     mPacketsInFlight++;
   }
 

--- a/uhal/uhal/src/common/ProtocolUDP.cpp
+++ b/uhal/uhal/src/common/ProtocolUDP.cpp
@@ -64,7 +64,7 @@ namespace uhal
     mEndpoint ( *boost::asio::ip::udp::resolver ( mIOservice ).resolve ( boost::asio::ip::udp::resolver::query ( boost::asio::ip::udp::v4() , aUri.mHostname , aUri.mPort ) ) ),
     mDeadlineTimer ( mIOservice ),
     mReplyMemory ( ),
-    mIOserviceWork ( mIOservice ),
+    mIOserviceWork ( mIOservice.get_executor() ),
     mDispatchThread ( [this] () { mIOservice.run(); } ),
     mDispatchQueue(),
     mReplyQueue(),

--- a/uhal/uhal/src/common/utilities/files.cpp
+++ b/uhal/uhal/src/common/utilities/files.cpp
@@ -44,7 +44,7 @@
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/asio/error.hpp>
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/ip/udp.hpp>
 #include <boost/asio/streambuf.hpp>
@@ -167,7 +167,7 @@ namespace uhal
 
       boost::system::error_code lErrorCode ( boost::asio::error::host_not_found );
       // The IO service everything will go through
-      boost::asio::io_service io_service;
+      boost::asio::io_context io_service;
       // Get a list of endpoints corresponding to the server name.
       boost::asio::ip::tcp::resolver resolver ( io_service );
       boost::asio::ip::tcp::resolver::query query ( lURLPair.first , "http" );

--- a/uhal/uhal/src/common/utilities/files.cpp
+++ b/uhal/uhal/src/common/utilities/files.cpp
@@ -45,6 +45,7 @@
 #include <boost/filesystem/operations.hpp>
 #include <boost/asio/error.hpp>
 #include <boost/asio/io_context.hpp>
+#include <boost/asio/connect.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/ip/udp.hpp>
 #include <boost/asio/streambuf.hpp>
@@ -176,7 +177,7 @@ namespace uhal
 
       try
       {
-        socket.connect ( results, lErrorCode );
+          boost::asio::connect ( socket, results, lErrorCode );
 
         if ( lErrorCode )
         {

--- a/uhal/uhal/src/common/utilities/files.cpp
+++ b/uhal/uhal/src/common/utilities/files.cpp
@@ -170,19 +170,13 @@ namespace uhal
       boost::asio::io_context io_service;
       // Get a list of endpoints corresponding to the server name.
       boost::asio::ip::tcp::resolver resolver ( io_service );
-      boost::asio::ip::tcp::resolver::query query ( lURLPair.first , "http" );
-      boost::asio::ip::tcp::resolver::iterator endpoint_iterator = resolver.resolve ( query );
-      boost::asio::ip::tcp::resolver::iterator end;
+      boost::asio::ip::tcp::resolver::results_type results = resolver.resolve ( lURLPair.first , "http" );
       // Try each endpoint until we successfully establish a connection.
       boost::asio::ip::tcp::socket socket ( io_service );
 
       try
       {
-        while ( lErrorCode && endpoint_iterator != end )
-        {
-          socket.close();
-          socket.connect ( *endpoint_iterator++, lErrorCode );
-        }
+        socket.connect ( results, lErrorCode );
 
         if ( lErrorCode )
         {


### PR DESCRIPTION
This PR makes ipbus uhal compile against Boost 1.86 (see #326 )

It is compatible with Boost 1.66 (Alma/RHEL 8), but not any earlier Boost versions