### PR TITLE
ipbusmmap client: Uninitialised member data bugfix

### DIFF
--- a/ci/build-rpm.yml
+++ b/ci/build-rpm.yml
@@ -153,7 +153,7 @@ build:alma9:arm64:
     - export REPO_DIR=${CI_PROJECT_DIR}/ci_results/repos/${OUTPUT_REPO_SUBDIR}
     - if [ -z "${CI_COMMIT_TAG}" ]; then export PACKAGE_RELEASE_SUFFIX=.autobuild_$(git log --pretty=format:'%h' -1) ; fi
     - curl -L http://github.com/zeux/pugixml/releases/download/v1.9/pugixml-1.9.zip -o extern/pugixml/pugixml-1.9.zip
-    - curl -L https://boostorg.jfrog.io/artifactory/main/release/1.66.0/source/boost_1_66_0.tar.bz2 -o extern/boost/boost_1_66_0.tar.bz2
+    - curl -L https://archives.boost.io/release/1.66.0/source/boost_1_66_0.tar.bz2 -o extern/boost/boost_1_66_0.tar.bz2
     - sed -i "s/PACKAGE_VER_MINOR = 2/PACKAGE_VER_MINOR = 9/g" extern/pugixml/Makefile
     - sed -i "s/PACKAGE_VER_MINOR = 53/PACKAGE_VER_MINOR = 66/g" extern/boost/Makefile
     - sed -i 's|cd ${ZIP_NAME}|cd ${ZIP_NAME}/${ZIP_NAME}|g' extern/pugixml/Makefile

--- a/uhal/uhal/src/common/ProtocolMmap.cpp
+++ b/uhal/uhal/src/common/ProtocolMmap.cpp
@@ -293,7 +293,6 @@ Mmap::Mmap ( const std::string& aId, const URI& aUri ) :
   mPublishedReplyPageCount(0),
   mReadReplyPageCount(0)
 {
-  std::cout << "Mmap<" << this << ">: Constructor (mDeviceFile=" << aUri.mHostname << ")" << std::endl;
   mSleepDuration = std::chrono::microseconds(50);
 
   for (const auto& lArg: aUri.mArguments) {
@@ -395,12 +394,10 @@ void Mmap::connect()
 
 void Mmap::connect(detail::ScopedSessionLock& aGuard)
 {
-  std::cout << "Mmap<" << this << ">: connect" << std::endl;
   // Read current value of session counter when reading status info from FPGA
   // (So that can check whether this info is up-to-date later on, when sending next request packet)
   mIPCExternalSessionActive = mIPCMutex->isActive() and (not mDeviceFile.haveLock());
   mIPCSessionCount = mIPCMutex->getCounter();
-  std::cout << "                    mIPCExternalSessionActive=" << mIPCExternalSessionActive << ", mIPCMutex->getCounter()=" << mIPCMutex->getCounter() << ", mIPCSessionCount=" << mIPCSessionCount << std::endl;
 
   log ( Debug() , "mmap client is opening device file " , Quote ( mDeviceFile.getPath() ) );
   std::vector<uint32_t> lValues;
@@ -453,14 +450,10 @@ void Mmap::write(const std::shared_ptr<Buffers>& aBuffers)
     // If these two numbers don't match, another client/process has sent packets
     // more recently than this client has, so must re-read status info
     if (mIPCExternalSessionActive or (mIPCMutex->getCounter() != mIPCSessionCount)) {
-      std::cout << "Mmap<" << this << ">: Detected that connect required" << std::endl;
-      std::cout << "                    mIPCExternalSessionActive=" << mIPCExternalSessionActive << ", mIPCMutex->getCounter()=" << mIPCMutex->getCounter() << ", mIPCSessionCount=" << mIPCSessionCount << std::endl;
       connect(lGuard);
     }
   }
 
-  std::cout << "Mmap<" << this << ">: Writing " << Integer(aBuffers->sendCounter() / 4) << "-word packet to page " << mIndexNextPage << " in " << mDeviceFile.getPath() << std::endl;
-  std::cout << "                    mIPCExternalSessionActive=" << mIPCExternalSessionActive << ", mIPCMutex->getCounter()=" << mIPCMutex->getCounter() << ", mIPCSessionCount=" << mIPCSessionCount << std::endl;
   log (Info(), "mmap client ", Quote(id()), ": Writing ", Integer(aBuffers->sendCounter() / 4), "-word packet to page ", Integer(mIndexNextPage), " in ", mDeviceFile.getPath());
 
   const uint32_t lHeaderWord = (0x10000 | (((aBuffers->sendCounter() / 4) - 1) & 0xFFFF));

--- a/uhal/uhal/src/common/SigBusGuard.cpp
+++ b/uhal/uhal/src/common/SigBusGuard.cpp
@@ -45,7 +45,9 @@ namespace uhal {
   volatile sig_atomic_t SigBusGuard::sProtected = 0;
 
   SigBusGuard::SigBusGuard() :
-    mLockGuard(sMutex)
+    mLockGuard(sMutex),
+    mAction({0}),
+    mOriginalAction({0})
   {
     // 1) Register our signal handler for SIGBUS, saving original in mOriginalAction
     log(Debug(), "Registering uHAL SIGBUS handler");

--- a/uhal/uhal/src/common/detail/RobustSessionMutex.cpp
+++ b/uhal/uhal/src/common/detail/RobustSessionMutex.cpp
@@ -88,12 +88,14 @@ bool RobustSessionMutex::isActive() const
 
 void RobustSessionMutex::startSession()
 {
+  std::cout << "RobustSessionMutex<" << this << ">::startSession()   [" << mCount << " -> " << mCount + 1 << "]" << std::endl;
   mCount++;
   mSessionActive = true;
 }
 
 void RobustSessionMutex::endSession()
 {
+  std::cout << "RobustSessionMutex<" << this << ">::endSession()   [mCount=" << mCount << "]" << std::endl;
   mSessionActive = false;
 }
 

--- a/uhal/uhal/src/common/detail/RobustSessionMutex.cpp
+++ b/uhal/uhal/src/common/detail/RobustSessionMutex.cpp
@@ -88,14 +88,12 @@ bool RobustSessionMutex::isActive() const
 
 void RobustSessionMutex::startSession()
 {
-  std::cout << "RobustSessionMutex<" << this << ">::startSession()   [" << mCount << " -> " << mCount + 1 << "]" << std::endl;
   mCount++;
   mSessionActive = true;
 }
 
 void RobustSessionMutex::endSession()
 {
-  std::cout << "RobustSessionMutex<" << this << ">::endSession()   [mCount=" << mCount << "]" << std::endl;
   mSessionActive = false;
 }
 


### PR DESCRIPTION
Two member variables in `SigBusGuard` (`mAction` & `mOriginalAction`) and one in `Mmap::File` (`mLocked`) previously weren't initialised, leading to undefined behaviour.