### PR TITLE
Avoid spurious warning for empty 'top nodes'

### DIFF
--- a/uhal/tools/scripts/gen_ipbus_addr_decode
+++ b/uhal/tools/scripts/gen_ipbus_addr_decode
@@ -100,8 +100,8 @@ class node(object):
         
 class nodetree(object):
 
-    def __init__(self):
-        self.root = node("TOP")
+    def __init__(self, width = None):
+        self.root = node("TOP", width=width)
 
 # Add a node to the tree
 
@@ -251,7 +251,9 @@ def main():
         
 # Build the node tree
 
-    t = nodetree()
+    f = device.getNode().getFirmwareInfo()
+    w = int(f["width"]) if "width" in f else None
+    t = nodetree(w)
     for i in device.getNodes():
         d = device.getNode(i)
         if d.getMask() == 0xffffffff:


### PR DESCRIPTION
For address tables with empty 'top' nodes', the address decoder generator warns about the top node having no width, even if the width is specified for that node. This is due to the fact that top nodes are treated specially, and no attributes are considered for such nodes.

This change fixes the above. Hence no more distracting messages about missing width specifiers.