### PR TITLE
Implement ldconf

### DIFF
--- a/uhal/config/mfRPMRules.mk
+++ b/uhal/config/mfRPMRules.mk
@@ -13,6 +13,9 @@ RPM_RELEASE_SUFFIX = ${RPM_DIST}$(if ${CXX_VERSION_TAG},.${CXX_VERSION_TAG},)
 
 PYTHON_VERSIONED_COMMAND := $(shell ${PYTHON} -c "from sys import version_info; print('python' + str(version_info[0]))")
 
+RPM_POST := $(if $(RPM_POST),$(RPM_POST),%{nil})
+RPM_POSTUN := $(if $(RPM_POSTUN),$(RPM_POSTUN),%{nil})
+
 export BUILD_HOME
 
 .PHONY: rpm _rpmall
@@ -47,6 +50,8 @@ _spec_update:
 	       -e 's|^.*__requires__.*|${REQUIRES_TAG}|' \
 	       -e 's|^BuildArch:.*|$(if ${PackageBuildArch},BuildArch: ${PackageBuildArch},\# BuildArch not specified)|' \
 	       -e 's#__python_versioned_command__#${PYTHON_VERSIONED_COMMAND}#' \
+	       -e 's#__rpm_post__#${RPM_POST}#' \
+	       -e 's#__rpm_postun__#${RPM_POSTUN}#' \
 	       ${PackagePath}/rpm/${PackageName}.spec
 	if [ "${BuildDebuginfoRPM}" == "1" ]; then sed -i '1 i\%define _build_debuginfo_package %{nil}' ${PackagePath}/rpm/${PackageName}.spec; fi
 

--- a/uhal/config/specTemplate.spec
+++ b/uhal/config/specTemplate.spec
@@ -11,6 +11,8 @@
 %define _summary __summary__
 %define _url __url__
 %define _python_versioned_command __python_versioned_command__
+%define _rpm_post __rpm_post__
+%define _rpm_postun __rpm_postun__
 
 
 %define percent %( echo "%" )
@@ -120,9 +122,11 @@ find ./ -type d -exec chmod 755 {} \;
 
 %clean
 
-%post 
+%post
+%{_rpm_post}
 
-%postun 
+%postun
+%{_rpm_postun}
 
 
 %files 

--- a/uhal/tools/Makefile
+++ b/uhal/tools/Makefile
@@ -14,10 +14,6 @@ PackageURL = https://ipbus.web.cern.ch/ipbus
 Packager = Kristian Harder, Dave Newbold, Tom Williams
 PackageBuildArch = noarch
 
-LD_CONF_FILE = /etc/ld.so.conf.d/uhal.conf
-RPM_POST := echo $(CACTUS_ROOT)/lib > $(LD_CONF_FILE); ldconfig
-RPM_POSTUN := if [ $$1 == 0 ]; then rm $(LD_CONF_FILE); ldconfig; fi
-
 .PHONY: _all build clean
 clean: ;
 _all: ;

--- a/uhal/tools/Makefile
+++ b/uhal/tools/Makefile
@@ -14,6 +14,9 @@ PackageURL = https://ipbus.web.cern.ch/ipbus
 Packager = Kristian Harder, Dave Newbold, Tom Williams
 PackageBuildArch = noarch
 
+LD_CONF_FILE = /etc/ld.so.conf.d/uhal.conf
+RPM_POST := echo $(CACTUS_ROOT)/lib > $(LD_CONF_FILE); ldconfig
+RPM_POSTUN := if [ $$1 == 0 ]; then rm $(LD_CONF_FILE); ldconfig; fi
 
 .PHONY: _all build clean
 clean: ;

--- a/uhal/uhal/Makefile
+++ b/uhal/uhal/Makefile
@@ -13,6 +13,9 @@ PackageDescription = uHAL Library
 PackageURL = https://ipbus.web.cern.ch/ipbus
 Packager = Andrew Rose, Tom Williams
 
+LD_CONF_FILE = /etc/ld.so.conf.d/uhal.conf
+RPM_POST := echo $(CACTUS_ROOT)/lib > $(LD_CONF_FILE); ldconfig
+RPM_POSTUN := if [ $$1 == 0 ]; then rm $(LD_CONF_FILE); ldconfig; fi
 
 Library = cactus_uhal_uhal
 LIBRARY_VER_ABI = $(PACKAGE_VER_MAJOR).$(PACKAGE_VER_MINOR)


### PR DESCRIPTION
I keep doing basic Linux support for people who forget to set their LD_LIBRARY_PATH.

So this change implements support for ldconf by adding a file /etc/ld.so.conf.d/uhal.conf, pointing to the uhal library path.