### PR TITLE
Minimal changes for Python 3.12 and 3.13 support

### DIFF
--- a/uhal/config/mfCommonDefs.mk
+++ b/uhal/config/mfCommonDefs.mk
@@ -23,9 +23,9 @@ MakeDir = mkdir -p
 
 
 PYTHON ?= python
-PYTHON_VERSION ?= $(shell ${PYTHON} -c "import distutils.sysconfig; print(distutils.sysconfig.get_python_version())")
-PYTHON_INCLUDE_PREFIX ?= $(shell ${PYTHON} -c "import distutils.sysconfig; print(distutils.sysconfig.get_python_inc())")
-PYTHON_LIB_PREFIX ?= $(shell ${PYTHON} -c "from distutils.sysconfig import get_python_lib; import os.path; print(os.path.split(get_python_lib(standard_lib=True))[0])")
+PYTHON_VERSION ?= $(shell ${PYTHON} -c "import sysconfig; print(sysconfig.get_python_version())")
+PYTHON_INCLUDE_PREFIX ?= $(shell ${PYTHON} -c "import sysconfig; print(sysconfig.get_path('include'))")
+PYTHON_LIB_PREFIX ?= $(shell ${PYTHON} -c "import sysconfig; print(sysconfig.get_path('stdlib'))")
 
 # Construct C++ compiler suffix for RPM release field (tested with clang & gcc)
 CXX_VERSION_TAG = $(word 1, $(shell ${CXX} --version))

--- a/uhal/config/mfPythonRPMRules.mk
+++ b/uhal/config/mfPythonRPMRules.mk
@@ -96,4 +96,4 @@ install: _setup_update
 	# Change into rpm/pkg to finally run the customized setup.py
 	if [ -f setup.cfg ]; then cp setup.cfg ${RPMBUILD_DIR}/ ; fi
 	cd ${RPMBUILD_DIR} && \
-	  bindir=$(bindir) ${PYTHON} ${PackageName}.py install $(if ${CUSTOM_INSTALL_PREFIX},--prefix=${prefix},) $(if ${CUSTOM_INSTALL_PREFIX}${CUSTOM_INSTALL_EXEC_PREFIX},--exec-prefix=${exec_prefix},)
+	  $(if ${CUSTOM_INSTALL_PREFIX},PYTHONPATH=${prefix}/lib/python${PYTHON_VERSION}/site-packages,) bindir=$(bindir) ${PYTHON} ${PackageName}.py install $(if ${CUSTOM_INSTALL_PREFIX},--prefix=${prefix},) $(if ${CUSTOM_INSTALL_PREFIX}${CUSTOM_INSTALL_EXEC_PREFIX},--exec-prefix=${exec_prefix},)

--- a/uhal/config/setupTemplate.py
+++ b/uhal/config/setupTemplate.py
@@ -1,6 +1,6 @@
 
 import os, sys
-from distutils.core import setup
+from setuptools import setup
 from os import walk
 from os.path import join, relpath
 

--- a/uhal/gui/Makefile
+++ b/uhal/gui/Makefile
@@ -9,7 +9,7 @@ PYTHON_VERSION_MAJOR_MINOR=$(shell ${PYTHON} -c "import sys; print(str(sys.versi
 Project = uhal
 Package = uhal/gui
 PackagePath = $(CACTUS_RPM_ROOT)/${Package}
-PackageName = cactuscore-uhal-python${PYTHON_VERSION_MAJOR_MINOR}-gui
+PackageName = cactuscore_uhal_python${PYTHON_VERSION_MAJOR_MINOR}_gui
 
 PackageDescription = Python GUI for uTCA HW access based on uHAL
 PackageURL = https://ipbus.web.cern.ch/ipbus

--- a/uhal/python/Makefile
+++ b/uhal/python/Makefile
@@ -15,7 +15,7 @@ endif
 Project = uhal
 Package = uhal/python
 PackagePath = $(CACTUS_RPM_ROOT)/${Package}
-PackageName = cactuscore-uhal-python${PYTHON_VERSION_MAJOR_MINOR}
+PackageName = cactuscore_uhal_python${PYTHON_VERSION_MAJOR_MINOR}
 
 PackageDescription = Python bindings for the uHAL library
 PackageURL = https://ipbus.web.cern.ch/ipbus


### PR DESCRIPTION
This is related to #323 and contains a rather minimal patch set to compile/install/build RPMs with Python 3.12 and Python 3.13. It was mostly tested on Alma 9 with Python 3.9/12/13.

It tries mostly to get rid of things that are definitely deprecated and/or removed in the latest Python versions:

- Replace use of distutils.sysconfig with equivalent sysconfig calls.
- Replace use of distutils.setup() with setuptools.setup() in setupTemplate.py
- For custom install prefix, make sure destination is in $PYTHONPATH during installation (required for generation of .pth file) - this is an obscure error.
- Change ${PackageName} variable for the two Python packages. The old name contains slashed (-) which is not allowed in sdist names anymore. sdist names have to contain only a single - which separates the package name from the version number. (https://packaging.python.org/en/latest/specifications/source-distribution-format/#source-distribution-file-name)

Calling 'python setup.py' directly is on its way out. I have further changes that replace the non-RPM installation with a '${PYTHON} -m pip install .' invocation. This allows to use the existing setup.py files but creates proper wheels instead of eggs, which allows a standard conforming installation.

The current patch does not work on Ubuntu 24.04 (Python 3.12)  - it fails to generate the necessary .pth file for the eggs.