### PR TITLE
Controlhub: Update to lager v3.9.2 and lager_syslog v3.0.3, to resolve build errors with newer Erlang releases

### DIFF
--- a/ci/build-rpm.yml
+++ b/ci/build-rpm.yml
@@ -1,6 +1,8 @@
 
 .template_build_rpm_yumrepo:
   stage: build
+  variables:
+    IPBUS_BUILD_SET: all
   before_script:
     # Fix for CERN k8s-provisioned shared runners: Limit number of opened file descriptors with ulimit
     - ulimit -n 1048576
@@ -11,9 +13,9 @@
     - export REPO_DIR=${CI_PROJECT_DIR}/ci_results/repos/${OUTPUT_REPO_SUBDIR}
     - if [ -z "${CI_COMMIT_TAG}" ]; then export PACKAGE_RELEASE_SUFFIX=.autobuild_$(git log --pretty=format:'%h' -1) ; fi
   script:
-    - make -k Set=all check-version
-    - make -k Set=all BUILD_UHAL_PYTHON=0 BUILD_UHAL_GUI=0
-    - make -k Set=all BUILD_UHAL_PYTHON=0 BUILD_UHAL_GUI=0 PACKAGE_RELEASE_SUFFIX=${PACKAGE_RELEASE_SUFFIX} rpm
+    - make -k Set=${IPBUS_BUILD_SET} check-version
+    - make -k Set=${IPBUS_BUILD_SET} BUILD_UHAL_PYTHON=0 BUILD_UHAL_GUI=0
+    - make -k Set=${IPBUS_BUILD_SET} BUILD_UHAL_PYTHON=0 BUILD_UHAL_GUI=0 PACKAGE_RELEASE_SUFFIX=${PACKAGE_RELEASE_SUFFIX} rpm
     - mkdir -p ${REPO_DIR}
     - cp -v `find . -iname "*.rpm"` ${REPO_DIR}
     - cp -v ${YUMGROUPS_FILE} ${REPO_DIR}/yumgroups.xml
@@ -93,6 +95,7 @@ build:centos7:x86:
   extends: .template_build_rpm_yumrepo:x86
   image: ${IPBUS_DOCKER_REGISTRY}/centos7/ipbus-sw-dev:2025.08.08__boost1.53.0_pugixml1.8
   variables:
+    IPBUS_BUILD_SET: uhal
     OUTPUT_REPO_SUBDIR: centos7/x86_64
     PYTHONS: "python2.7 python3.4 python3.6"
     YUMGROUPS_FILE: ci/yum/yumgroups-centos7.xml
@@ -101,6 +104,7 @@ build:centos7:arm64:
   extends: .template_build_rpm_yumrepo:arm64
   image: ${IPBUS_DOCKER_REGISTRY}/centos7/ipbus-sw-dev:2025.08.08__boost1.53.0_pugixml1.8
   variables:
+    IPBUS_BUILD_SET: uhal
     OUTPUT_REPO_SUBDIR: centos7/aarch64
     PYTHONS: "python2.7 python3.4 python3.6"
     YUMGROUPS_FILE: ci/yum/yumgroups-centos7.xml
@@ -160,9 +164,9 @@ build:alma9:arm64:
     - sudo yum -y install zlib-devel
     - source /opt/rh/devtoolset-8/enable
   script:
-    - make -k Set=all BUILD_BOOST=1 BUILD_PUGIXML=1 BUILD_UHAL_PYTHON=0 check-version
-    - make -k Set=all BUILD_BOOST=1 BUILD_PUGIXML=1 BUILD_UHAL_PYTHON=0
-    - make -k Set=all BUILD_BOOST=1 BUILD_PUGIXML=1 BUILD_UHAL_PYTHON=0 PACKAGE_RELEASE_SUFFIX=${PACKAGE_RELEASE_SUFFIX} rpm
+    - make -k Set=uhal BUILD_BOOST=1 BUILD_PUGIXML=1 BUILD_UHAL_PYTHON=0 check-version
+    - make -k Set=uhal BUILD_BOOST=1 BUILD_PUGIXML=1 BUILD_UHAL_PYTHON=0
+    - make -k Set=uhal BUILD_BOOST=1 BUILD_PUGIXML=1 BUILD_UHAL_PYTHON=0 PACKAGE_RELEASE_SUFFIX=${PACKAGE_RELEASE_SUFFIX} rpm
     - mkdir -p ${REPO_DIR}
     - cp `find . -iname "*.rpm"` ${REPO_DIR}
     - cp ${YUMGROUPS_FILE} ${REPO_DIR}/yumgroups.xml

--- a/ci/build-rpm.yml
+++ b/ci/build-rpm.yml
@@ -144,7 +144,6 @@ build:alma9:arm64:
   stage: build
   image: ${IPBUS_DOCKER_REGISTRY}/centos7/ipbus-sw-dev-gcc8:2025.08.08
   variables:
-    FF_KUBERNETES_HONOR_ENTRYPOINT: 1
     GIT_CLONE_PATH: ${CI_BUILDS_DIR}/${CI_PROJECT_PATH}_____
     PYTHONS: "python2.7 python3.4 python3.6"
     YUMGROUPS_FILE: ci/yum/yumgroups-centos7-gcc8.xml
@@ -159,6 +158,7 @@ build:alma9:arm64:
     - sed -i 's|cd ${ZIP_NAME}|cd ${ZIP_NAME}/${ZIP_NAME}|g' extern/pugixml/Makefile
     - git diff
     - sudo yum -y install zlib-devel
+    - source /opt/rh/devtoolset-8/enable
   script:
     - make -k Set=all BUILD_BOOST=1 BUILD_PUGIXML=1 BUILD_UHAL_PYTHON=0 check-version
     - make -k Set=all BUILD_BOOST=1 BUILD_PUGIXML=1 BUILD_UHAL_PYTHON=0

--- a/ci/build-simple.yml
+++ b/ci/build-simple.yml
@@ -1,11 +1,13 @@
 
 .template_build_simple:
   stage: build
+  variables:
+    IPBUS_BUILD_SET: all
   script:
     # Fix for CERN k8s-provisioned shared runners: Limit number of opened file descriptors with ulimit
     - ulimit -n 1048576
-    - make -k Set=all check-version
-    - make -k Set=all
+    - make -k Set=${IPBUS_BUILD_SET} check-version
+    - make -k Set=${IPBUS_BUILD_SET}
   artifacts:
     paths:
       - '**/*.exe'
@@ -23,6 +25,7 @@ build:centos7:static:
   extends: .template_build_simple
   image: ${IPBUS_DOCKER_REGISTRY}/centos7/ipbus-sw-dev-static:2024.10.10__boost1.53.0_pugixml1.8
   variables:
+    IPBUS_BUILD_SET: uhal
     BUILD_STATIC: 1
     BUILD_UHAL_PYTHON: 0
     BUILD_UHAL_GUI: 0

--- a/ci/tests.yml
+++ b/ci/tests.yml
@@ -174,10 +174,6 @@ test_tools:centos7:x86:
   extends: .template_test:centos7:x86
   <<: *test_tools_jobScript
 
-test_controlhub:centos7:x86:
-  extends: .template_test:centos7:x86
-  <<: *test_controlhub_plainScripts_jobScript
-
 
 test_core:centos7:arm64:
   extends: .template_test:centos7:arm64
@@ -203,10 +199,6 @@ test_gui:centos7:arm64:
 test_tools:centos7:arm64:
   extends: .template_test:centos7:arm64
   <<: *test_tools_jobScript
-
-test_controlhub:centos7:arm64:
-  extends: .template_test:centos7:arm64
-  <<: *test_controlhub_plainScripts_jobScript
 
 
 test_core:centos7-gcc8:
@@ -239,10 +231,6 @@ test_gui:centos7-gcc8:
 test_tools:centos7-gcc8:
   extends: .template_test:centos7-gcc8
   <<: *test_tools_jobScript
-
-test_controlhub:centos7-gcc8:
-  extends: .template_test:centos7-gcc8
-  <<: *test_controlhub_plainScripts_jobScript
 
 
 test_core:alma8:

--- a/ci/tests.yml
+++ b/ci/tests.yml
@@ -289,8 +289,9 @@ test_python:alma9:
         UHAL_PYTHON_RPM: cactuscore-uhal-python311
       - PYTHON: python3.12
         UHAL_PYTHON_RPM: cactuscore-uhal-python312
-      - PYTHON: python3.13
-        UHAL_PYTHON_RPM: cactuscore-uhal-python313
+      # Temporarily dropping the Python 3.13 test job, since python3.13-numpy RPM hasn't been aded to EPEL yet.
+      # - PYTHON: python3.13
+      #   UHAL_PYTHON_RPM: cactuscore-uhal-python313
 
 test_tools:alma9:
   extends: .template_test:alma9

--- a/controlhub/rebar.config
+++ b/controlhub/rebar.config
@@ -3,9 +3,9 @@
 % DEPENDENCIES
 
 {deps, [
-  {lager, "3\.2\.2", {git, "https://github.com/basho/lager.git", {tag, "3.2.4"}}},
+  {lager, "3\.9\.2", {git, "https://github.com/erlang-lager/lager.git", {tag, "3.9.2"}}},
   {syslog, "1\.0\.5", {git, "https://github.com/Vagabond/erlang-syslog.git", {tag, "1.0.5"}}},
-  {lager_syslog, "2\.1\.2", {git, "https://github.com/basho/lager_syslog.git", {tag, "3.0.3"}}}
+  {lager_syslog, "2\.1\.2", {git, "https://github.com/erlang-lager/lager_syslog.git", {tag, "3.0.3"}}}
 ]}.
 
 

--- a/controlhub/rel/reltool.config
+++ b/controlhub/rel/reltool.config
@@ -21,7 +21,7 @@
        {boot_rel, "controlhub"},
        {profile, embedded},
        {incl_cond, derived},
-       {excl_archive_filters, [".*"]}, %% Do not archive built libs
+       % {excl_archive_filters, [".*"]}, %% Do not archive built libs
        {excl_sys_filters, ["^bin/(?!start_clean.boot)",
                            "^erts.*/bin/(dialyzer|typer)",
                            "^erts.*/(doc|info|include|lib|man|src)"]},

--- a/uhal/config/mfPythonRPMRules.mk
+++ b/uhal/config/mfPythonRPMRules.mk
@@ -100,4 +100,4 @@ install: _setup_update
 	# Change into rpm/pkg to finally run the customized setup.py
 	if [ -f setup.cfg ]; then cp setup.cfg ${RPMBUILD_DIR}/ ; fi
 	cd ${RPMBUILD_DIR} && \
-	  $(if ${CUSTOM_INSTALL_PREFIX},PYTHONPATH=${prefix}/lib/python${PYTHON_VERSION}/site-packages,) bindir=$(bindir) ${PYTHON} ${PackageName}.py install $(if ${CUSTOM_INSTALL_PREFIX},--prefix=${prefix},) $(if ${CUSTOM_INSTALL_PREFIX}${CUSTOM_INSTALL_EXEC_PREFIX},--exec-prefix=${exec_prefix},)
+	  $(if ${CUSTOM_INSTALL_PREFIX},PYTHONPATH=${prefix}/lib/python${PYTHON_VERSION}/site-packages,) bindir=$(bindir) ${PYTHON} ${PythonDistName}.py install $(if ${CUSTOM_INSTALL_PREFIX},--prefix=${prefix},) $(if ${CUSTOM_INSTALL_PREFIX}${CUSTOM_INSTALL_EXEC_PREFIX},--exec-prefix=${exec_prefix},)


### PR DESCRIPTION
Side effect: Drop support for ControlHub on CentOS7