### PR TITLE
Refine support for Python 3.12+

### DIFF
--- a/ci/build-rpm.yml
+++ b/ci/build-rpm.yml
@@ -91,7 +91,7 @@
 
 build:centos7:x86:
   extends: .template_build_rpm_yumrepo:x86
-  image: ${IPBUS_DOCKER_REGISTRY}/centos7/ipbus-sw-dev:2024.10.10__boost1.53.0_pugixml1.8
+  image: ${IPBUS_DOCKER_REGISTRY}/centos7/ipbus-sw-dev:python-setuptools-cf83d57f__boost1.53.0_pugixml1.8
   variables:
     OUTPUT_REPO_SUBDIR: centos7/x86_64
     PYTHONS: "python2.7 python3.4 python3.6"
@@ -99,7 +99,7 @@ build:centos7:x86:
 
 build:centos7:arm64:
   extends: .template_build_rpm_yumrepo:arm64
-  image: ${IPBUS_DOCKER_REGISTRY}/centos7/ipbus-sw-dev:2024.10.10__boost1.53.0_pugixml1.8
+  image: ${IPBUS_DOCKER_REGISTRY}/centos7/ipbus-sw-dev:python-setuptools-cf83d57f__boost1.53.0_pugixml1.8
   variables:
     OUTPUT_REPO_SUBDIR: centos7/aarch64
     PYTHONS: "python2.7 python3.4 python3.6"
@@ -108,41 +108,41 @@ build:centos7:arm64:
 
 build:alma8:x86:
   extends: .template_build_rpm_yumrepo:x86
-  image: ${IPBUS_DOCKER_REGISTRY}/alma8/ipbus-sw-dev:2024.10.10__boost1.66.0_pugixml1.13
+  image: ${IPBUS_DOCKER_REGISTRY}/alma8/ipbus-sw-dev:python-setuptools-cf83d57f__boost1.66.0_pugixml1.13
   variables:
     OUTPUT_REPO_SUBDIR: alma8/x86_64
-    PYTHONS: "python3.6 python3.8 python3.9 python3.11"
+    PYTHONS: "python3.6 python3.8 python3.9 python3.11 python3.12"
     YUMGROUPS_FILE: ci/yum/yumgroups-el8.xml
 
 build:alma8:arm64:
   extends: .template_build_rpm_yumrepo:arm64
-  image: ${IPBUS_DOCKER_REGISTRY}/alma8/ipbus-sw-dev:2024.10.10__boost1.66.0_pugixml1.13
+  image: ${IPBUS_DOCKER_REGISTRY}/alma8/ipbus-sw-dev:python-setuptools-cf83d57f__boost1.66.0_pugixml1.13
   variables:
     OUTPUT_REPO_SUBDIR: alma8/aarch64
-    PYTHONS: "python3.6 python3.8 python3.9 python3.11"
+    PYTHONS: "python3.6 python3.8 python3.9 python3.11 python3.12"
     YUMGROUPS_FILE: ci/yum/yumgroups-el8.xml
 
 
 build:alma9:x86:
   extends: .template_build_rpm_yumrepo:x86
-  image: ${IPBUS_DOCKER_REGISTRY}/alma9/ipbus-sw-dev:2023.08.30__boost1.75.0_pugixml1.13
+  image: ${IPBUS_DOCKER_REGISTRY}/alma9/ipbus-sw-dev:python-setuptools-cf83d57f__boost1.75.0_pugixml1.13
   variables:
     OUTPUT_REPO_SUBDIR: alma9/x86_64
-    PYTHONS: "python3.9 python3.11"
+    PYTHONS: "python3.9 python3.11 python3.12 python3.13"
     YUMGROUPS_FILE: ci/yum/yumgroups-el9.xml
 
 build:alma9:arm64:
   extends: .template_build_rpm_yumrepo:arm64
-  image: ${IPBUS_DOCKER_REGISTRY}/alma9/ipbus-sw-dev:2023.08.30__boost1.75.0_pugixml1.13
+  image: ${IPBUS_DOCKER_REGISTRY}/alma9/ipbus-sw-dev:python-setuptools-cf83d57f__boost1.75.0_pugixml1.13
   variables:
     OUTPUT_REPO_SUBDIR: alma9/aarch64
-    PYTHONS: "python3.9 python3.11"
+    PYTHONS: "python3.9 python3.11 python3.12 python3.13"
     YUMGROUPS_FILE: ci/yum/yumgroups-el9.xml
 
 
 .build:centos7-gcc8:
   stage: build
-  image: ${IPBUS_DOCKER_REGISTRY}/centos7/ipbus-sw-dev-gcc8:2024.10.10
+  image: ${IPBUS_DOCKER_REGISTRY}/centos7/ipbus-sw-dev-gcc8:python-setuptools-cf83d57f
   variables:
     FF_KUBERNETES_HONOR_ENTRYPOINT: 1
     GIT_CLONE_PATH: ${CI_BUILDS_DIR}/${CI_PROJECT_PATH}_____

--- a/ci/tests.yml
+++ b/ci/tests.yml
@@ -262,6 +262,8 @@ test_python:alma8:
         UHAL_PYTHON_RPM: cactuscore-uhal-python39
       - PYTHON: python3.11
         UHAL_PYTHON_RPM: cactuscore-uhal-python311
+      - PYTHON: python3.12
+        UHAL_PYTHON_RPM: cactuscore-uhal-python312
 
 test_tools:alma8:
   extends: .template_test:alma8
@@ -285,6 +287,10 @@ test_python:alma9:
         UHAL_PYTHON_RPM: cactuscore-uhal-python39
       - PYTHON: python3.11
         UHAL_PYTHON_RPM: cactuscore-uhal-python311
+      - PYTHON: python3.12
+        UHAL_PYTHON_RPM: cactuscore-uhal-python312
+      - PYTHON: python3.13
+        UHAL_PYTHON_RPM: cactuscore-uhal-python313
 
 test_tools:alma9:
   extends: .template_test:alma9

--- a/uhal/gui/Makefile
+++ b/uhal/gui/Makefile
@@ -9,7 +9,8 @@ PYTHON_VERSION_MAJOR_MINOR=$(shell ${PYTHON} -c "import sys; print(str(sys.versi
 Project = uhal
 Package = uhal/gui
 PackagePath = $(CACTUS_RPM_ROOT)/${Package}
-PackageName = cactuscore_uhal_python${PYTHON_VERSION_MAJOR_MINOR}_gui
+PackageName = cactuscore-uhal-python${PYTHON_VERSION_MAJOR_MINOR}-gui
+PythonDistName = uhal_gui
 
 PackageDescription = Python GUI for uTCA HW access based on uHAL
 PackageURL = https://ipbus.web.cern.ch/ipbus

--- a/uhal/python/Makefile
+++ b/uhal/python/Makefile
@@ -15,7 +15,8 @@ endif
 Project = uhal
 Package = uhal/python
 PackagePath = $(CACTUS_RPM_ROOT)/${Package}
-PackageName = cactuscore_uhal_python${PYTHON_VERSION_MAJOR_MINOR}
+PackageName = cactuscore-uhal-python${PYTHON_VERSION_MAJOR_MINOR}
+PythonDistName = uhal
 
 PackageDescription = Python bindings for the uHAL library
 PackageURL = https://ipbus.web.cern.ch/ipbus


### PR DESCRIPTION
This branch refines the changes from #339 in order to support hyphens in RPM names again. It also updates the CI jobs to build & test on Python 3.12 & 3.13, and to use new `ipbus-docker` images which contain `setuptools` for all installed Python versions.