### PR TITLE
Fix TCP send error with Erlang 26

### DIFF
--- a/controlhub/rebar.config
+++ b/controlhub/rebar.config
@@ -24,5 +24,8 @@
             % (Erlang releases from 17 onwards do not put R in front of name
             {platform_define, "^(R|17).*", old_erlang_time_api},
             {platform_define, "^(R|17|18).*", orig_udp_port_command_format},
-            {platform_define, "^(R|17|18|19).*", bypass_gen_udp_send}
+            {platform_define, "^(R|17|18|19).*", bypass_gen_udp_send},
+            % Directly invoke 'port_command' rather than gen_tcp:send in earlier releases in order to improve performance.
+            % This no longer works from v26, by which point the gen_tcp:send performance issue appear to have been resolved: https://github.com/erlang/otp/issues/7130
+            {platform_define, "^(R|17|18|19|20|21|22|23|24|25).*", bypass_gen_tcp_send}
             ]}.


### PR DESCRIPTION
This branch updates the ControlHub to use `gen_tcp:send` rather than `port_command` for sending replies to the uHAL client from Erlang v26. From that release, `port_command` sends the wrong data (the first two bytes are missing), leading to the Alma 9 error reported in #342 